### PR TITLE
feat: complete Proxmox Utility Toolkit with scripts, docs, and validation fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Contributions are welcome. Please:
+
+1. Fork the repo
+2. Create a feature branch (`git checkout -b feature/your-feature`)
+3. Ensure all scripts pass `shellcheck`
+4. Test on Proxmox VE 8.x
+5. Submit a pull request
+
+## Script Standards
+
+- Source `lib/common.sh`
+- Use `set -euo pipefail`
+- Include `--help` flag
+- Validate all user inputs
+- Use `log_*` functions for output
+- Default to safe mode for destructive operations (`--dry-run` or confirmation prompt)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Derek Armstrong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,225 +1,126 @@
-# 🚀 Proxmox Utility Toolkit
+# Proxmox Utility Toolkit
 
-> **Your homelab sidekick for VMs, containers, backups, and automation magic.**
+Bash scripts for managing Proxmox VE 8.x on Debian 12. VMs, containers, backups, networking, and storage — all with consistent error handling, input validation, and dry-run safety.
 
----
+## Prerequisites
 
-## 🎯 What's This All About?
+- Proxmox VE 8.x on Debian 12 (bookworm)
+- Run scripts as **root** on a Proxmox node
+- SSH public key ready for cloud-init setups
 
-Welcome! This is your go-to collection of scripts and docs for taming Proxmox VE 8.x on Debian 12. Whether you're spinning up VMs, managing containers, setting up backups, or diving into Kubernetes clusters—there's something here to make your life easier.
-
-**⚠️ Quick reality check:** This is a **learning playground**. Production homelabs thrive on simplicity. Use these techniques to build skills, not because you need them for daily services. Complexity = more failure points. Keep your production stuff simple, folks!
-
----
-
-## 🏃 Quick Start (Let's Go!)
+## Quick Start
 
 ```bash
-# 1. Clone and set up
-git clone https://github.com/dereklarmstrong/proxmox.git
+# Clone and configure
+git clone https://git.orcafam.com/dereklarmstrong/proxmox.git
 cd proxmox
-cp config.example.sh config.sh         # Edit this with your settings
-./scripts/test.sh                      # Optional: run the test suite
+cp config.example.sh config.sh    # Edit with your settings
 
-# 2. Enable the Proxmox community repo
-bash scripts/setup/pve_community_repo.sh
+# Create a cloud-init template
+./scripts/vm/create_template.sh --image https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img \
+  --name ubuntu-2404-template --vmid 9000
 
-# 3. Create a cloud-init template (pick your flavor)
-# Ubuntu 24.04 (you'll need the SHA):
-bash scripts/vm/create_cloud_init_template.sh -i 9000 --sha256 <ubuntu_sha>
+# Clone a VM with static IP
+./scripts/vm/clone_cloud_init.sh --template 9000 --name dev-box --vmid 110 \
+  --ip 10.0.1.50/24 --gateway 10.0.1.1 --sshkey ~/.ssh/id_ed25519.pub --start
 
-# Oracle Linux 9 (checksum included):
-bash scripts/vm/create_cloud_init_template.sh -i 9100 --os ol9
-
-# 4. Clone a VM with your homelab IP
-bash scripts/vm/clone_vm.sh -s 9000 -d 150 -n web01 -i 192.168.1.60/24 -g 192.168.1.1
-
-# 5. (Optional) Deploy a Kubernetes cluster
-bash scripts/k8s/deploy_ol_k8s_cluster.sh --config config.k8s.sh
+# List everything
+./scripts/vm/list_vms.sh
+./scripts/containers/list_containers.sh
 ```
 
----
+## Scripts at a Glance
 
-## 📋 Prerequisites
+### VM Management (`scripts/vm/`)
 
-- ✅ Proxmox VE 8.x on Debian 12 (bookworm)
-- ✅ Run scripts as **root** on a Proxmox node
-- ✅ SSH public key ready for cloud-init and container setups
+| Script | Description |
+|--------|-------------|
+| `list_vms.sh` | List all VMs and containers with status, CPU, memory |
+| `clone_cloud_init.sh` | Clone a cloud-init template with static IP and SSH key |
+| `create_template.sh` | Create a cloud-init enabled VM template from disk image |
+| `snapshot_vm.sh` | Create snapshots of VMs |
 
----
+### Container Management (`scripts/containers/`)
 
-## 🎨 What's Inside?
+| Script | Description |
+|--------|-------------|
+| `create_lxc.sh` | Create LXC containers from templates with network config |
+| `destroy_lxc.sh` | Destroy containers (with confirmation by default) |
+| `list_containers.sh` | List containers with status, CPU, memory |
 
-### 🗂️ Documentation
+### Backup (`scripts/backup/`)
 
-| Category | Docs |
-|----------|------|
-| **Getting Started** | [`README.md`](README.md) • [`docs/cheatsheet.md`](docs/cheatsheet.md) |
-| **Backup & Recovery** | [`backup/readme.md`](backup/readme.md) • [`backup/backup-strategy.md`](backup/backup-strategy.md) • [`backup/gfs-strategy.md`](backup/gfs-strategy.md) • [`backup/pbs-setup.md`](backup/pbs-setup.md) • [`backup/restore-procedures.md`](backup/restore-procedures.md) • [`backup/verification.md`](backup/verification.md) |
-| **GPU Passthrough** | [`gpu-passthrough/readme.md`](gpu-passthrough/readme.md) • [`gpu-passthrough/nvidia-cuda.md`](gpu-passthrough/nvidia-cuda.md) • [`gpu-passthrough/amd-rocm.md`](gpu-passthrough/amd-rocm.md) • [`gpu-passthrough/gaming.md`](gpu-passthrough/gaming.md) • [`gpu-passthrough/troubleshooting.md`](gpu-passthrough/troubleshooting.md) |
-| **Networking** | [`networking/readme.md`](networking/readme.md) • [`networking/vlan-setup.md`](networking/vlan-setup.md) • [`networking/firewall-rules.md`](networking/firewall-rules.md) • [`networking/sdn-guide.md`](networking/sdn-guide.md) |
-| **Automation** | [`automation/readme.md`](automation/readme.md) • [`automation/learning-path.md`](automation/learning-path.md) • [`automation/ansible/readme.md`](automation/ansible/readme.md) • [`automation/terraform/readme.md`](automation/terraform/readme.md) |
-| **Security** | [`security.md`](security.md) • [`security/readme.md`](security/readme.md) • [`security/auditing.md`](security/auditing.md) • [`security/cis-benchmarks.md`](security/cis-benchmarks.md) • [`security/incident-response.md`](security/incident-response.md) • [`security/zero-trust.md`](security/zero-trust.md) |
-| **Services** | [`services/vm-patterns.md`](services/vm-patterns.md) • [`services/container-patterns.md`](services/container-patterns.md) • [`services/service-deployments.md`](services/service-deployments.md) |
+| Script | Description |
+|--------|-------------|
+| `backup_status.sh` | Check backup status with filtering and JSON output |
+| `gfs_retention.sh` | Manage GFS backup retention (daily/weekly/monthly/yearly) |
 
----
+### Networking (`scripts/network/`)
 
-## 🛠️ Scripts at a Glance
+| Script | Description |
+|--------|-------------|
+| `network_report.sh` | Generate network configuration report |
+| `vlan_setup.sh` | Set up VLAN network bridges |
 
-### ⚙️ Setup & Utilities
-- [`scripts/setup/pve_community_repo.sh`](scripts/setup/pve_community_repo.sh:1) — Enable the no-subscription repo
-- [`scripts/download_github_keys.sh`](scripts/download_github_keys.sh:1) — Pull GitHub SSH keys into authorized_keys
+### Storage (`scripts/storage/`)
 
-### 🖥️ VM Templates & Cloning
-- [`scripts/vm/create_cloud_init_template.sh`](scripts/vm/create_cloud_init_template.sh:1) — Build cloud-init templates (Ubuntu/Oracle Linux)
-- [`scripts/vm/clone_vm.sh`](scripts/vm/clone_vm.sh:1) — Full clone with static IP + SSH key
-- [`scripts/vm/destroy_vm.sh`](scripts/vm/destroy_vm.sh:1) — Nuke one or more VMs
-- [`scripts/vm/check_template.sh`](scripts/vm/check_template.sh:1) — Validate templates and cloud-init config
-- [`scripts/vm/compute_image_sha256.sh`](scripts/vm/compute_image_sha256.sh:1) — Download and checksum an image
-- [`scripts/vm/console.sh`](scripts/vm/console.sh:1) — Quick console access
-- [`scripts/vm/find_ip.sh`](scripts/vm/find_ip.sh:1) — Find a VM/container's IP by name
-- [`scripts/vm/info.sh`](scripts/vm/info.sh:1) — Detailed VM/container info
-- [`scripts/vm/snapshot.sh`](scripts/vm/snapshot.sh:1) — Snapshot management
+| Script | Description |
+|--------|-------------|
+| `cleanup_orphaned.sh` | Find and remove orphaned disk images |
 
-### 🐧 Container Management
-- [`scripts/containers/create_container.sh`](scripts/containers/create_container.sh:1) — Create LXC from template
-- [`scripts/containers/destroy_container.sh`](scripts/containers/destroy_container.sh:1) — Destroy containers
-- [`scripts/containers/list_templates.sh`](scripts/containers/list_templates.sh:1) — List available LXC templates
+### API (`scripts/api/`)
 
-### 💾 Backups
-- [`scripts/backup/backup_vm.sh`](scripts/backup/backup_vm.sh:1) — Backup a single VM/CT
-- [`scripts/backup/backup_all.sh`](scripts/backup/backup_all.sh:1) — Backup everything
-- [`scripts/backup/prune_backups.sh`](scripts/backup/prune_backups.sh:1) — Clean up old backups
-- [`scripts/backup/report.sh`](scripts/backup/report.sh:1) — Generate backup status report
+| Script | Description |
+|--------|-------------|
+| `api_wrapper.sh` | Wrapper for Proxmox VE API calls |
 
-### 🔌 API Helpers
-- [`scripts/api/create_api_token.sh`](scripts/api/create_api_token.sh:1) — Create API tokens
-- [`scripts/api/api_request.sh`](scripts/api/api_request.sh:1) — Minimal curl wrapper for API calls
+## Configuration
 
-### ☸️ Kubernetes
-- [`scripts/k8s/deploy_ol_k8s_cluster.sh`](scripts/k8s/deploy_ol_k8s_cluster.sh:1) — Deploy Oracle Linux K8s cluster
-
-### 🌐 Network & Storage
-- [`scripts/network/show.sh`](scripts/network/show.sh:1) — Show network configs for all VMs/CTs
-- [`scripts/storage/cleanup.sh`](scripts/storage/cleanup.sh:1) — Clean up unused storage
-- [`scripts/storage/disk_usage.sh`](scripts/storage/disk_usage.sh:1) — Disk usage by VM/container
-
-### 📊 Status & Monitoring
-- [`scripts/status.sh`](scripts/status.sh:1) — Dashboard-style status overview
-
-### 🚀 Automation & Deployment
-- [`scripts/deploy_base_vm_set.sh`](scripts/deploy_base_vm_set.sh:1) — Deploy base VMs for K8s
-- [`scripts/create_vm_full_clone.sh`](scripts/create_vm_full_clone.sh:1) — Full clone with network + SSH setup
-
-### 🧪 Testing
-- [`scripts/test.sh`](scripts/test.sh:1) — Run the test suite (vendored bats)
-
----
-
-## ⚙️ Configuration
-
-Just copy the template and tweak it:
+Copy the example config and edit:
 
 ```bash
 cp config.example.sh config.sh
 ```
 
-Key settings to adjust: `DEFAULT_STORAGE`, `DEFAULT_BRIDGE`, `SSH_KEY_PATH`, `TEMPLATE_ID_START`, `BACKUP_STORAGE`, `BACKUP_RETENTION_DAYS`.
+Key settings: `DEFAULT_STORAGE`, `DEFAULT_BRIDGE`, `SSH_KEY_PATH`, `PROXMOX_HOST`, `PROXMOX_USER`, `PROXMOX_PASSWORD`.
 
----
+## Script Standards
 
-## 🎓 Learning Paths
+All scripts follow these conventions:
 
-### 🌱 Beginner
-1. Start with basic VM/container creation
-2. Learn simple backup procedures
-3. Understand basic networking
+- Source `lib/common.sh` for logging, validation, and utilities
+- Use `set -euo pipefail` for strict error handling
+- Include `--help` / `-h` usage documentation
+- Validate all inputs before execution
+- Default to `--dry-run` for destructive operations
+- Pass `shellcheck` without warnings
 
-### 🌿 Intermediate
-1. Implement VLANs and firewall rules
-2. Set up automated backups with retention
-3. Learn Ansible for configuration management
-
-### 🌳 Advanced
-1. Deploy Proxmox Backup Server
-2. Configure GPU passthrough for AI/gaming
-3. Implement Terraform infrastructure as code
-
-### 🌲 Expert
-1. Zero trust architecture implementation
-2. CIS benchmark compliance
-3. Automated incident response
-
----
-
-## 📚 Handy Links
-
-- 🔗 [Proxmox API Viewer](https://pve.proxmox.com/pve-docs/api-viewer/index.html)
-- 📖 [Proxmox Documentation](https://pve.proxmox.com/pve-docs/)
-- 💾 [Proxmox Backup Server](https://www.proxmox.com/en/proxmox-backup-server)
-- ☁️ [Cloud-init Documentation](https://cloud-init.io/)
-
----
-
-## 📁 Repository Structure
+## Repository Structure
 
 ```
 proxmox/
-├── README.md                    # You are here 👀
-├── SECURITY.md                  # Security hardening guide
-├── docs/
-│   ├── cheatsheet.md            # CLI command reference
-│   └── storage_strategy.md      # Storage type comparison
-├── backup/
-│   ├── readme.md                # Backup docs index
-│   ├── backup-strategy.md       # 3-2-1 backup, GFS retention
-│   ├── gfs-strategy.md          # GFS retention policy
-│   ├── pbs-setup.md             # Proxmox Backup Server
-│   ├── restore-procedures.md    # Restore procedures
-│   └── verification.md          # Backup verification
-├── gpu-passthrough/
-│   ├── readme.md                # GPU passthrough index
-│   ├── nvidia-cuda.md           # CUDA for AI/ML
-│   ├── amd-rocm.md              # ROCm for AMD GPUs
-│   ├── gaming.md                # Gaming VM setup
-│   └── troubleshooting.md       # Troubleshooting guide
-├── networking/
-│   ├── readme.md                # Networking index
-│   ├── vlan-setup.md            # VLAN configuration
-│   ├── firewall-rules.md        # Firewall rules
-│   └── sdn-guide.md             # SDN configuration
-├── automation/
-│   ├── readme.md                # Automation index
-│   ├── learning-path.md         # Learning path
-│   ├── ansible/
-│   │   ├── readme.md            # Ansible guide
-│   │   └── playbooks/
-│   └── terraform/
-│       ├── readme.md            # Terraform guide
-│       └── main.tf
-├── security/
-│   ├── readme.md                # Security index
-│   ├── auditing.md              # Security auditing
-│   ├── cis-benchmarks.md        # CIS compliance
-│   ├── incident-response.md     # Incident response
-│   └── zero-trust.md            # Zero trust architecture
-├── services/
-│   ├── vm-patterns.md           # VM deployment patterns
-│   ├── container-patterns.md    # Container patterns
-│   └── service-deployments.md   # Service deployments
-├── scripts/                     # Utility scripts galore
-│   ├── setup/
+├── README.md
+├── LICENSE
+├── CONTRIBUTING.md
+├── config.example.sh
+├── lib/
+│   └── common.sh              # Shared library (logging, validation, API helpers)
+├── scripts/
 │   ├── vm/
 │   ├── containers/
 │   ├── backup/
-│   ├── api/
-│   ├── k8s/
 │   ├── network/
 │   ├── storage/
-│   └── status.sh
-└── tests/                       # Test suite
+│   └── api/
+└── docs/
 ```
 
----
+## Links
 
-> **💡 Remember:** This is for **learning**. Keep your production homelabs simple. Use these techniques to build skills, not because you need them for daily services. Complexity = more failure points.
+- [Proxmox API Viewer](https://pve.proxmox.com/pve-docs/api-viewer/index.html)
+- [Proxmox Documentation](https://pve.proxmox.com/pve-docs/)
+- [Cloud-init Documentation](https://cloud-init.io/)
+
+## License
+
+MIT — See [LICENSE](LICENSE) for details.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,166 @@
+# API Reference
+
+## Authentication
+
+### API Token (Recommended)
+
+Create a token via Proxmox GUI: Datacenter → Permissions → API Tokens
+
+```bash
+# Use token with api_wrapper.sh
+./scripts/api/api_wrapper.sh \
+  --token root@pam!mytoken \
+  --secret "your-secret-here" \
+  GET /version
+```
+
+### Username/Password (Legacy)
+
+```bash
+./scripts/api/api_wrapper.sh \
+  --user root@pam \
+  --password "your_password" \
+  GET /version
+```
+
+## Common API Calls
+
+### Version
+
+```bash
+./scripts/api/api_wrapper.sh GET /version
+```
+
+### Nodes
+
+```bash
+# List all nodes
+./scripts/api/api_wrapper.sh GET /cluster/resources --data '{"type":"node"}'
+
+# Node status
+./scripts/api/api_wrapper.sh GET /nodes/pve/status
+```
+
+### VMs
+
+```bash
+# List all VMs
+./scripts/api/api_wrapper.sh GET /cluster/resources --data '{"type":"vm"}'
+
+# VM status
+./scripts/api/api_wrapper.sh GET /nodes/pve/qemu/100/status/current
+
+# Start VM
+./scripts/api/api_wrapper.sh POST /nodes/pve/qemu/100/status/start --data '{}'
+
+# Stop VM
+./scripts/api/api_wrapper.sh POST /nodes/pve/qemu/100/status/stop --data '{"unmount":true}'
+
+# Shutdown VM
+./scripts/api/api_wrapper.sh POST /nodes/pve/qemu/100/status/shutdown --data '{}'
+```
+
+### Containers
+
+```bash
+# List all containers
+./scripts/api/api_wrapper.sh GET /cluster/resources --data '{"type":"lxc"}'
+
+# Container status
+./scripts/api/api_wrapper.sh GET /nodes/pve/lxc/200/status/current
+```
+
+### Storage
+
+```bash
+# List storages
+./scripts/api/api_wrapper.sh GET /nodes/pve/storage
+
+# Storage status
+./scripts/api/api_wrapper.sh GET /nodes/pve/storage/local-lvm/status
+```
+
+### Backups
+
+```bash
+# List backups
+./scripts/api/api_wrapper.sh GET /nodes/pve/storage/backup-lvm/content
+
+# Create backup
+./scripts/api/api_wrapper.sh POST /nodes/pve/storage/backup-lvm/content \
+  --data '{"vmid":100,"mode":"snapshot","storage":"backup-lvm"}'
+```
+
+### Network
+
+```bash
+# List networks
+./scripts/api/api_wrapper.sh GET /nodes/pve/network
+
+# Create VLAN
+./scripts/api/api_wrapper.sh POST /nodes/pve/network \
+  --data '{"iface":"vmbr100.100","method":"manual","vlan-raw-device":"vmbr100","vlan-id":"100"}'
+```
+
+## API Patterns
+
+### Filter Resources
+
+```bash
+# VMs only
+./scripts/api/api_wrapper.sh GET /cluster/resources --data '{"type":"vm"}'
+
+# Node only
+./scripts/api/api_wrapper.sh GET /cluster/resources --data '{"type":"node"}'
+
+# Storage only
+./scripts/api/api_wrapper.sh GET /cluster/resources --data '{"type":"storage"}'
+```
+
+### JSON Output
+
+All API calls output JSON by default. Pipe to `jq` for formatting:
+
+```bash
+./scripts/api/api_wrapper.sh GET /cluster/resources | jq '.data[] | {id, name, type}'
+```
+
+### Error Handling
+
+API errors return HTTP status codes:
+
+- `200` — Success
+- `400` — Bad request (invalid parameters)
+- `401` — Unauthorized (bad credentials/token)
+- `403` — Forbidden (no permissions)
+- `404` — Not found
+- `500` — Server error
+
+## Using pvesh
+
+The `pvesh` command-line tool is built into Proxmox:
+
+```bash
+# List VMs
+pvesh get /cluster/resources --type vm
+
+# Get node info
+pvesh get /nodes/pve
+
+# Create VM
+pvesh create /nodes/pve/qemu --memory 2048 --cores 2 --name test-vm
+```
+
+## API Wrapper Functions
+
+`lib/common.sh` includes helper functions:
+
+```bash
+source lib/common.sh
+
+# Get data via pvesh
+pvesh_get /nodes/pve/qemu/100/status/current
+
+# Post data via pvesh
+pvesh_post /nodes/pve/qemu/100/status/start --data '{}'
+```

--- a/docs/backup_strategy.md
+++ b/docs/backup_strategy.md
@@ -1,0 +1,80 @@
+# Backup Strategy
+
+## The 3-2-1 Rule
+
+- **3** copies of your data
+- **2** different storage mediums
+- **1** copy offsite
+
+## Backup Types
+
+### Full Backup
+
+Complete copy of the VM/container. Used as the base for incremental backups.
+
+```bash
+# Proxmox native backup (creates .vma.zst)
+pvesm backup 100 --storage backup-lvm --mode full
+```
+
+### Incremental Backup
+
+Only changed blocks since last backup. Faster and uses less space.
+
+```bash
+pvesm backup 100 --storage backup-lvm --mode incremental
+```
+
+### Snapshot
+
+Point-in-time state capture. Not a backup — must be synced to storage.
+
+```bash
+./scripts/vm/snapshot_vm.sh --vmid 100 --name pre-upgrade
+```
+
+## Backup Schedule
+
+| Frequency | Retention | Purpose |
+|-----------|-----------|---------|
+| Daily | 7 days | Recent recovery |
+| Weekly | 4 weeks | Week-level recovery |
+| Monthly | 6 months | Month-level recovery |
+| Yearly | 1 year | Compliance, long-term |
+
+## Best Practices
+
+### What to Backup
+
+- All production VMs and containers
+- Configuration files (`/etc/`, `/root/`)
+- Database dumps
+- Application data volumes
+
+### What Not to Backup
+
+- Temporary files
+- Cache directories
+- Swap files
+- Already-redundant data (ZFS mirrors, RAID)
+
+### Storage Considerations
+
+- Keep backup storage separate from production storage
+- Use dedicated backup server (Proxmox Backup Server) for large environments
+- Monitor backup storage usage regularly
+- Test restores quarterly
+
+## Backup Verification
+
+```bash
+# Check backup status
+./scripts/backup/backup_status.sh
+
+# Verify backup integrity
+pvesm backup 100 --storage backup-lvm --mode verify
+```
+
+## Restore Procedures
+
+See `docs/restore_procedures.md` for detailed restore instructions.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,119 @@
+# Getting Started with Proxmox Utility Toolkit
+
+## Initial Setup
+
+### 1. Clone the Repository
+
+```bash
+git clone https://git.orcafam.com/dereklarmstrong/proxmox.git
+cd proxmox
+```
+
+### 2. Configure
+
+```bash
+cp config.example.sh config.sh
+```
+
+Edit `config.sh` with your environment settings:
+
+```bash
+# Proxmox connection
+PROXMOX_HOST="192.168.1.3"
+PROXMOX_USER="root@pam"
+PROXMOX_PASSWORD="your_password"
+
+# Defaults
+DEFAULT_STORAGE="local-lvm"
+DEFAULT_BRIDGE="vmbr0"
+SSH_KEY_PATH="$HOME/.ssh/id_ed25519.pub"
+
+# Backup
+BACKUP_STORAGE="backup-lvm"
+BACKUP_RETENTION_DAYS=7
+```
+
+### 3. Verify Connection
+
+```bash
+# Test API connectivity
+./scripts/api/api_wrapper.sh GET /version
+```
+
+## First VM
+
+### Create a Cloud-Init Template
+
+```bash
+./scripts/vm/create_template.sh \
+  --image https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img \
+  --name ubuntu-2404-template \
+  --vmid 9000 \
+  --sshkey ~/.ssh/id_ed25519.pub
+```
+
+### Clone a VM
+
+```bash
+./scripts/vm/clone_cloud_init.sh \
+  --template 9000 \
+  --name dev-box \
+  --vmid 110 \
+  --ip 10.0.1.50/24 \
+  --gateway 10.0.1.1 \
+  --sshkey ~/.ssh/id_ed25519.pub \
+  --start
+```
+
+### Connect
+
+```bash
+ssh ubuntu@10.0.1.50
+```
+
+## First Container
+
+```bash
+./scripts/containers/create_lxc.sh \
+  --ctid 200 \
+  --template local:vztmpl/debian-12-standard.tar.zst \
+  --hostname web01 \
+  --ip 10.0.1.60/24 \
+  --gateway 10.0.1.1 \
+  --start
+```
+
+## Common Workflows
+
+### List Everything
+
+```bash
+./scripts/vm/list_vms.sh
+./scripts/containers/list_containers.sh
+```
+
+### Check Backups
+
+```bash
+./scripts/backup/backup_status.sh
+./scripts/backup/backup_status.sh --days 30 --failed-only
+```
+
+### Network Report
+
+```bash
+./scripts/network/network_report.sh
+```
+
+### Cleanup Storage
+
+```bash
+./scripts/storage/cleanup_orphaned.sh --dry-run
+./scripts/storage/cleanup_orphaned.sh --force
+```
+
+## Next Steps
+
+- Read individual script `--help` for full option lists
+- Review `docs/backup_strategy.md` for backup best practices
+- Review `docs/network_guide.md` for advanced networking

--- a/docs/network_guide.md
+++ b/docs/network_guide.md
@@ -1,0 +1,141 @@
+# Network Configuration Guide
+
+## Network Architecture
+
+### Standard Setup
+
+```
+eth0 (physical)
+  └── vmbr0 (bridge)
+        ├── VMs (VLAN 100)
+        ├── Containers (VLAN 200)
+        └── Management traffic
+```
+
+### VLAN Configuration
+
+#### Create a VLAN Bridge
+
+```bash
+./scripts/network/vlan_setup.sh \
+  --vlan 100 \
+  --bridge vmbr100 \
+  --parent eth0 \
+  --description "Development VLAN"
+```
+
+#### Manual VLAN Setup
+
+Edit `/etc/network/interfaces`:
+
+```
+auto vmbr0
+iface vmbr0 inet static
+    address 192.168.1.3/24
+    gateway 192.168.1.1
+    bridge-ports eth0
+    bridge-stp off
+    bridge-fd 0
+
+# VLAN 100
+auto vmbr100.100
+iface vmbr100.100 inet manual
+    vlan-raw-device vmbr100
+    vlan-id 100
+```
+
+### Firewall Rules
+
+#### Basic VM Firewall
+
+```bash
+# Enable firewall on VM 100
+qm set 100 --firewall 1
+
+# Allow SSH inbound
+qm set 100 --firewall_policy inbound:tcp,22,allow
+
+# Allow HTTP/HTTPS
+qm set 100 --firewall_policy inbound:tcp,80,allow
+qm set 100 --firewall_policy inbound:tcp,443,allow
+```
+
+#### Container Firewall
+
+```bash
+pct set 200 --firewall 1
+pct set 200 --firewall_policy inbound:tcp,22,allow
+```
+
+## Network Diagnostics
+
+### Check Network Status
+
+```bash
+./scripts/network/network_report.sh
+```
+
+### Find VM IP Address
+
+```bash
+# From Proxmox shell
+arp -a | grep <MAC_address>
+
+# Or use the API
+./scripts/api/api_wrapper.sh GET /nodes/pve/qemu/100/status/state
+```
+
+### Test Connectivity
+
+```bash
+# From Proxmox node
+ping -c 3 10.0.1.50
+
+# Check routing
+ip route get 10.0.1.50
+
+# Check bridge members
+brctl show vmbr0
+```
+
+## Common Issues
+
+### VM Cannot Reach Network
+
+1. Check bridge configuration: `cat /etc/network/interfaces`
+2. Verify VM network settings: `qm config <vmid>`
+3. Check bridge is up: `ip link show vmbr0`
+4. Verify DHCP/static IP configuration
+
+### VLAN Not Working
+
+1. Check VLAN is configured: `ip link show | grep vlan`
+2. Verify VLAN ID on switch port
+3. Check bridge VLAN filtering: `bridge vlan show`
+
+### DNS Resolution Fails
+
+1. Check `/etc/resolv.conf`
+2. Verify nameserver in VM config: `qm config <vmid> | grep nameserver`
+3. Test DNS: `nslookup example.com`
+
+## Advanced Topics
+
+### SDN (Software Defined Networking)
+
+SDN provides automated IP allocation, VLAN management, and firewall rules.
+
+```bash
+# Create SDN zone
+pvesh create /cluster/sdn/zones --name dev-vlan --type vlan --vid 100
+
+# Assign IP range
+pvesh create /cluster/sdn/ipspaces --name dev-ips --type ipset \
+  --ips 10.0.100.0/24
+```
+
+### MACVLAN for Containers
+
+```bash
+pct set 200 --net0 "name=eth0,bridge=vmbr0,hwaddr=,ip=dhcp,tag=100,type=macvlan"
+```

--- a/docs/storage_guide.md
+++ b/docs/storage_guide.md
@@ -1,0 +1,148 @@
+# Storage Management
+
+## Storage Types
+
+### LVM-Thin
+
+Best for performance. Supports snapshots and thin provisioning.
+
+```
+Storage: local-lvm
+Type: LVM-Thin
+Pool: pve
+```
+
+### Directory (ext4/xfs)
+
+Simple, reliable. Good for backups.
+
+```
+Storage: local
+Type: Directory
+Path: /var/lib/vz
+```
+
+### ZFS
+
+Best for data integrity. Supports snapshots, compression, and deduplication.
+
+```
+Storage: zfs-pool
+Type: ZFS Pool
+Pool: rpool/data
+```
+
+### NFS
+
+Network storage. Good for shared storage in cluster.
+
+```
+Storage: nfs-backup
+Type: NFS
+Path: /mnt/pve/nfs-backup
+```
+
+## Disk Formats
+
+### qcow2
+
+QEMU copy-on-write format. Supports snapshots, compression, and encryption.
+
+```bash
+# Convert to qcow2
+qemu-img convert -f raw -O qcow2 disk.raw disk.qcow2
+
+# Check image info
+qemu-img info disk.qcow2
+```
+
+### raw
+
+Raw disk image. Maximum performance, no overhead.
+
+```bash
+# Create raw disk
+qemu-img create -f raw disk.raw 20G
+```
+
+### vmdk
+
+VMware disk format. Useful for cross-platform compatibility.
+
+## Storage Commands
+
+### Check Storage Status
+
+```bash
+pvesm status
+pvesm status --content images
+pvesm status --content backup
+```
+
+### Disk Usage by VM
+
+```bash
+# List all disk usage
+pvesm status --content images
+
+# Check specific VM disk
+qm config 100 | grep -E "^(scsi|virtio|sata)"
+```
+
+### Cleanup Orphaned Disks
+
+```bash
+# Preview orphaned files
+./scripts/storage/cleanup_orphaned.sh --dry-run
+
+# Delete orphaned files
+./scripts/storage/cleanup_orphaned.sh --force
+```
+
+## Storage Best Practices
+
+### Performance
+
+- Use LVM-Thin or ZFS for VM disks
+- Enable discard/trim: `qm set 100 --scsi0 discards=set`
+- Use SSD/NVMe for production workloads
+- Avoid network storage for database VMs
+
+### Capacity Planning
+
+- Keep storage usage below 80%
+- Monitor disk growth trends
+- Set up alerts at 70% and 90%
+- Plan for 6-month growth
+
+### Snapshots
+
+- Snapshots are not backups
+- Remove snapshots after verification
+- Avoid long-lived snapshots (performance impact)
+- Use for pre-upgrade safety only
+
+## Storage Migration
+
+### Move VM Disk Between Storages
+
+```bash
+# Stop VM
+qm stop 100
+
+# Move disk
+qm move-disk 100 scsi0 backup-lvm
+
+# Start VM
+qm start 100
+```
+
+### Resize Disk
+
+```bash
+# Resize LVM-Thin disk
+qm resize 100 scsi0 +20G
+
+# Resize ZFS disk
+qm resize 100 scsi0 50G
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,227 @@
+# Troubleshooting Guide
+
+## Common Issues
+
+### Script Errors
+
+#### "command not found"
+
+```bash
+# Ensure you're on Proxmox node
+which qm
+which pct
+which pvesm
+
+# Install missing tools
+apt update && apt install -y proxmox-small-fs
+```
+
+#### Permission Denied
+
+All scripts must run as root:
+
+```bash
+sudo ./scripts/vm/list_vms.sh
+```
+
+#### Connection Refused
+
+Check Proxmox connectivity:
+
+```bash
+# Test API
+curl -k -u root@pam https://192.168.1.3:8006/api2/json/version
+
+# Check if Proxmox services are running
+systemctl status pveproxy
+systemctl status pvedaemon
+```
+
+### VM Issues
+
+#### VM Won't Start
+
+```bash
+# Check VM config
+qm config 100
+
+# Check for locked state
+qm unlock 100
+
+# Check storage availability
+pvesm status
+
+# Check logs
+tail -f /var/log/syslog | grep qemu
+```
+
+#### VM Network Issues
+
+```bash
+# Check bridge
+brctl show vmbr0
+
+# Check VM network config
+qm config 100 | grep net
+
+# Test from host
+ping -c 3 <vm_ip>
+```
+
+#### VM Disk Full
+
+```bash
+# Check disk usage inside VM
+ssh vm "df -h"
+
+# Resize disk from host
+qm resize 100 scsi0 +10G
+
+# Check disk info
+qemu-img info /var/lib/vz/images/100/vm-100-disk-0.raw
+```
+
+### Container Issues
+
+#### Container Won't Start
+
+```bash
+# Check container config
+pct config 200
+
+# Check template exists
+pct list-templates
+
+# Check storage
+pvesm status
+```
+
+#### Container Network Issues
+
+```bash
+# Check container network config
+pct config 200 | grep net
+
+# Check host routing
+ip route
+
+# Test DNS resolution
+nslookup example.com
+```
+
+### Backup Issues
+
+#### Backup Fails
+
+```bash
+# Check backup storage
+pvesm status --content backup
+
+# Check available space
+df -h /var/lib/vz/dump
+
+# Check backup logs
+grep "vzdump" /var/log/syslog
+```
+
+#### Restore Fails
+
+```bash
+# Verify backup file exists
+ls -la /var/lib/vz/dump/vzdump-qemu-100-2024_01_01-12_00_00.vma.zst
+
+# Check backup integrity
+vma zst test /var/lib/vz/dump/vzdump-qemu-100-2024_01_01-12_00_00.vma.zst
+```
+
+### Storage Issues
+
+#### Storage Not Available
+
+```bash
+# Check storage configuration
+cat /etc/pve/storage.cfg
+
+# Verify storage path
+ls -la /var/lib/vz
+
+# Check filesystem
+df -h
+```
+
+#### Disk Space Full
+
+```bash
+# Find large files
+find /var/lib/vz -type f -size +1G -exec ls -lh {} \;
+
+# Clean old backups
+./scripts/backup/gfs_retention.sh --force
+
+# Clean orphaned disks
+./scripts/storage/cleanup_orphaned.sh --force
+```
+
+### Snapshot Issues
+
+#### Snapshot Too Large
+
+```bash
+# List snapshots
+qm snapshots 100
+
+# Remove old snapshots
+qm snapshots 100 | awk 'NR>1 {print $1}' | head -1 | xargs -I {} qm snapshot 100 {} --delete
+
+# Check snapshot size
+qm config 100 | grep snap
+```
+
+#### Snapshot Freeze
+
+```bash
+# Check if filesystem is frozen
+qm config 100 | grep freeze
+
+# Unfreeze
+qm freeze 100 --unfreeze
+```
+
+## Debug Mode
+
+### Enable Verbose Logging
+
+```bash
+# Run with bash debug mode
+bash -x ./scripts/vm/list_vms.sh
+```
+
+### Check Proxmox Logs
+
+```bash
+# System logs
+tail -f /var/log/syslog
+
+# Proxmox logs
+tail -f /var/log/pveproxy/access.log
+
+# QEMU logs
+tail -f /var/log/qemu/*.log
+```
+
+### API Debug
+
+```bash
+# Enable API logging
+systemctl restart pveproxy
+
+# Check API logs
+tail -f /var/log/pveproxy/error.log
+```
+
+## Getting Help
+
+1. Check script `--help` for usage
+2. Review `lib/common.sh` for utility functions
+3. Search Proxmox forums: https://forum.proxmox.com
+4. Check Proxmox documentation: https://pve.proxmox.com/pve-docs/

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -5,37 +5,90 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-# Colors for log output
+# --- Colors ---
 if [ -t 1 ]; then
-  COLOR_RESET="\033[0m"
-  COLOR_GREEN="\033[32m"
-  COLOR_YELLOW="\033[33m"
-  COLOR_RED="\033[31m"
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'
+  CYAN='\033[0;36m'
+  NC='\033[0m'
 else
-  COLOR_RESET=""
-  COLOR_GREEN=""
-  COLOR_YELLOW=""
-  COLOR_RED=""
+  RED=''
+  GREEN=''
+  YELLOW=''
+  BLUE=''
+  CYAN=''
+  NC=''
 fi
 
-log_info() { echo -e "${COLOR_GREEN}[INFO]${COLOR_RESET} $*"; }
-log_warn() { echo -e "${COLOR_YELLOW}[WARN]${COLOR_RESET} $*"; }
-log_error() { echo -e "${COLOR_RED}[ERROR]${COLOR_RESET} $*" 1>&2; }
+# --- Logging ---
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+log_debug() { [[ "${DEBUG:-0}" == "1" ]] && echo -e "${BLUE}[DEBUG]${NC} $*"; }
 
-require_root() {
-  if [ "${REQUIRE_ROOT_BYPASS:-0}" = "1" ]; then
-    return
-  fi
-  if [ "${EUID:-$(id -u)}" -ne 0 ]; then
-    log_error "This script must be run as root."
-    exit 1
-  fi
+# --- Error handling ---
+die() { log_error "$@"; exit 1; }
+
+# --- Dependency checks ---
+require_cmd() {
+  command -v "$1" &>/dev/null || die "Required command '$1' not found. Install it and retry."
 }
 
-# Load configuration file if present; fall back to built-in defaults
+require_root() {
+  if [[ "${REQUIRE_ROOT_BYPASS:-0}" == "1" ]]; then
+    return
+  fi
+  [[ "$(id -u)" -eq 0 ]] || die "This script must be run as root."
+}
+
+# --- Proxmox checks ---
+require_proxmox() {
+  require_cmd pvesh
+  require_cmd qm
+  require_cmd pct
+}
+
+# --- Input validation ---
+validate_vmid() {
+  local vmid="$1"
+  [[ "$vmid" =~ ^[0-9]+$ ]] || die "Invalid VMID: '$vmid'. Must be a positive integer."
+  [[ "$vmid" -ge 100 ]] || die "VMID must be >= 100. Got: $vmid"
+}
+
+validate_ip() {
+  local ip="$1"
+  [[ "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(/[0-9]{1,2})?$ ]] \
+    || die "Invalid IP address: '$ip'"
+}
+
+# --- Proxmox API helpers ---
+pvesh_get()  { pvesh get "$@" --output-format json 2>/dev/null; }
+pvesh_post() { pvesh create "$@" --output-format json 2>/dev/null; }
+
+# --- Confirmation prompt ---
+confirm() {
+  local msg="${1:-Are you sure?}"
+  read -rp "$msg [y/N]: " response
+  [[ "$response" =~ ^[Yy]$ ]] || die "Aborted by user."
+}
+
+# --- VM/CT existence ---
+check_vm_exists() {
+  local vmid="$1"
+  qm config "$vmid" &>/dev/null
+}
+
+check_ct_exists() {
+  local ctid="$1"
+  pct config "$ctid" &>/dev/null
+}
+
+# --- Config loading ---
 source_config() {
-  local config_file=${CONFIG_FILE:-"./config.sh"}
-  if [ -f "$config_file" ]; then
+  local config_file="${CONFIG_FILE:-./config.sh}"
+  if [[ -f "$config_file" ]]; then
     # shellcheck disable=SC1090
     source "$config_file"
   fi
@@ -48,23 +101,24 @@ source_config() {
 : "${SSH_KEY_PATH:=~/.ssh/id_rsa.pub}"
 : "${DEFAULT_GATEWAY:=}"
 : "${TEMPLATE_ID_START:=9000}"
-: "${BACKUP_STORAGE:=local}" # vzdump target storage
+: "${BACKUP_STORAGE:=local}"
 : "${BACKUP_RETENTION_DAYS:=30}"
 
+# --- System info ---
 get_pve_version() {
-  if command -v pveversion >/dev/null 2>&1; then
+  if command -v pveversion &>/dev/null; then
     pveversion | awk -F'[ /]' 'NR==1 {print $2}'
   fi
 }
 
 get_debian_codename() {
-  if [ -f /etc/os-release ]; then
+  if [[ -f /etc/os-release ]]; then
     # shellcheck disable=SC1091
     . /etc/os-release
     echo "$VERSION_CODENAME"
     return
   fi
-  if command -v lsb_release >/dev/null 2>&1; then
+  if command -v lsb_release &>/dev/null; then
     lsb_release -cs
     return
   fi
@@ -72,26 +126,8 @@ get_debian_codename() {
   echo "bookworm"
 }
 
-check_vm_exists() {
-  local vmid="$1"
-  if qm config "$vmid" >/dev/null 2>&1; then
-    return 0
-  fi
-  return 1
-}
-
-check_ct_exists() {
-  local ctid="$1"
-  if pct config "$ctid" >/dev/null 2>&1; then
-    return 0
-  fi
-  return 1
-}
-
+# --- SSH key helper ---
 ensure_ssh_key() {
   local key_path="$1"
-  if [ ! -f "$key_path" ]; then
-    log_error "SSH key not found at $key_path"
-    exit 1
-  fi
+  [[ -f "$key_path" ]] || die "SSH key not found at $key_path"
 }

--- a/scripts/api/api_wrapper.sh
+++ b/scripts/api/api_wrapper.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Wrapper for Proxmox VE API calls
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <method> <path> [options]
+
+Make API calls to the Proxmox VE API.
+
+Required:
+  <method>     HTTP method: GET, POST, PUT, DELETE
+  <path>       API path (e.g. /nodes/pve/storage/status)
+
+Options:
+  --data <json>  JSON data for POST/PUT requests
+  --output <f>   Output file (default: stdout)
+  --token <id>   API token ID (e.g. root@pam!mytoken)
+  --secret <s>   API token secret
+  --host <h>     Proxmox host (default: $PROXMOX_HOST)
+  --user <u>     Username (default: $PROXMOX_USER)
+  --password <p> Password (default: $PROXMOX_PASSWORD)
+  -h, --help     Show this help
+
+Examples:
+  $(basename "$0") GET /version
+  $(basename "$0") GET /nodes/pve/storage/status
+  $(basename "$0") POST /nodes/pve/qemu/100/status/stop --data '{"unmount":true}'
+  $(basename "$0") DELETE /nodes/pve/lxc/200
+EOF
+}
+
+method=""
+api_path=""
+data=""
+output_file=""
+token_id=""
+token_secret=""
+host=""
+user=""
+password=""
+
+# Parse positional args
+if [[ $# -ge 1 ]]; then
+  method=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+fi
+if [[ $# -ge 2 ]]; then
+  api_path="$2"
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --data)     data="$2"; shift 2 ;;
+    --output)   output_file="$2"; shift 2 ;;
+    --token)    token_id="$2"; shift 2 ;;
+    --secret)   token_secret="$2"; shift 2 ;;
+    --host)     host="$2"; shift 2 ;;
+    --user)     user="$2"; shift 2 ;;
+    --password) password="$2"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *)          shift ;;
+  esac
+done
+
+# Validate method
+[[ "$method" =~ ^(GET|POST|PUT|DELETE)$ ]] || die "Method must be GET, POST, PUT, or DELETE"
+
+# Validate path
+[[ "$api_path" =~ ^/ ]] || die "Path must start with /"
+
+# Set defaults
+host="${host:-$PROXMOX_HOST}"
+user="${user:-$PROXMOX_USER}"
+password="${password:-$PROXMOX_PASSWORD}"
+
+log_info "API Call: $method $api_path"
+[[ -n "$data" ]] && log_info "Data: $data"
+echo ""
+
+# Build curl command
+curl_cmd=(curl -s -k)
+curl_cmd+=(-H "Accept: application/json")
+
+# Authentication
+if [[ -n "$token_id" && -n "$token_secret" ]]; then
+  curl_cmd+=(-H "Authorization: APIToken=${token_id}=${token_secret}")
+elif [[ -n "$user" && -n "$password" ]]; then
+  # Get ticket
+  ticket_data=$(curl -s -k -X POST "https://${host}:8006/api2/json/access/ticket" \
+    -d "username=${user}&password=${password}" 2>/dev/null)
+  ticket=$(echo "$ticket_data" | grep -o '"ticket":"[^"]*"' | cut -d'"' -f4)
+  csrf=$(echo "$ticket_data" | grep -o '"CSRFPreventionToken":"[^"]*"' | cut -d'"' -f4)
+  if [[ -z "$ticket" ]]; then
+    die "Failed to authenticate with Proxmox API"
+  fi
+  curl_cmd+=(-b "PVEAuthCookie=${ticket}")
+  curl_cmd+=(-H "CSRFPreventionToken: ${csrf}")
+fi
+
+# Build URL
+url="https://${host}:8006/api2/json${api_path}"
+
+# Add data for POST/PUT
+if [[ "$method" == "POST" || "$method" == "PUT" ]]; then
+  curl_cmd+=(-X "$method" -H "Content-Type: application/json" -d "$data" "$url")
+elif [[ "$method" == "DELETE" ]]; then
+  curl_cmd+=(-X DELETE "$url")
+else
+  curl_cmd+=(-X GET "$url")
+fi
+
+# Execute
+result=$("${curl_cmd[@]}" 2>/dev/null) || die "API call failed"
+
+# Output
+if [[ -n "$output_file" ]]; then
+  echo "$result" > "$output_file"
+  log_info "Output written to $output_file"
+else
+  echo "$result"
+fi

--- a/scripts/backup/backup_status.sh
+++ b/scripts/backup/backup_status.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# Check backup status for VMs and containers
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Check backup status for VMs and containers.
+
+Options:
+  --vmid <id>        Check specific VMID
+  --ctid <id>        Check specific CTID
+  --storage <store>  Filter by storage name
+  --json             Output in JSON format
+  --days <n>         Show backups from last N days (default: 7)
+  -h, --help         Show this help
+
+Examples:
+  $(basename "$0")                 # Last 7 days, all backups
+  $(basename "$0") --vmid 100      # VM 100 only
+  $(basename "$0") --days 30       # Last 30 days
+EOF
+}
+
+vmid=""
+ctid=""
+storage=""
+output_json=0
+days=7
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vmid)     vmid="$2"; shift 2 ;;
+    --ctid)     ctid="$2"; shift 2 ;;
+    --storage)  storage="$2"; shift 2 ;;
+    --json)     output_json=1; shift ;;
+    --days)     days="$2"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *)          die "Unknown option: $1" ;;
+  esac
+done
+
+[[ "$days" =~ ^[0-9]+$ ]] || die "Days must be a positive integer"
+
+is_local=0
+if [[ -d /etc/pve ]] || command -v pvesh &>/dev/null && pvesh get /version &>/dev/null 2>&1; then
+  is_local=1
+fi
+
+log_info "Checking backups from last $days days"
+echo ""
+
+declare -a ids=()
+declare -a types=()
+declare -a dates=()
+declare -a sizes=()
+declare -a storages=()
+
+if [[ $is_local -eq 1 ]]; then
+  # Parse vzdump entries from syslog
+  local_days=$((days + 1))
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    # Extract timestamp (last 24 chars before "vzdump")
+    ts=$(echo "$line" | sed -n 's/.*\(....-..-.. ..:..:..\).*vzdump/\1/p')
+    [[ -z "$ts" ]] && continue
+
+    # Extract ID, type, status, storage
+    id=$(echo "$line" | grep -oP '(?:vm|lxc|container)[_-](\d+)' | head -1 | grep -oP '\d+')
+    [[ -z "$id" ]] && id=$(echo "$line" | grep -oP 'vzdump[._-]*(\d+)' | head -1 | grep -oP '\d+')
+    [[ -z "$id" ]] && continue
+
+    if echo "$line" | grep -qP 'vzdump(?:\.qemu|\.lxc)?(?:[_-](\d+))?' ; then
+      if echo "$line" | grep -q 'vm'; then
+        type="vm"
+      elif echo "$line" | grep -qP 'lxc|container'; then
+        type="ct"
+      else
+        type="vm"
+      fi
+    else
+      type="vm"
+    fi
+
+    status="unknown"
+    if echo "$line" | grep -qi 'finished OK'; then
+      status="success"
+    elif echo "$line" | grep -qi 'ERR\|fail\|ERROR'; then
+      status="failed"
+    fi
+
+    stg=$(echo "$line" | grep -oP 'storage[= ]+\K\S+' | head -1)
+    [[ -z "$stg" ]] && stg=$(echo "$line" | grep -oP '(?:backup/|dump\.|\.)(\S+?)(?:/|\.|vz)' | head -1)
+    [[ -z "$stg" ]] && stg="unknown"
+
+    # Filter by storage
+    if [[ -n "$storage" && "$stg" != "$storage" ]]; then
+      continue
+    fi
+
+    # Filter by ID type
+    if [[ -n "$vmid" && "$type" != "vm" && "$id" != "$vmid" ]]; then
+      continue
+    fi
+    if [[ -n "$ctid" && "$type" != "ct" && "$id" != "$ctid" ]]; then
+      continue
+    fi
+
+    date_str=$(date -d "$ts" +%Y-%m-%d 2>/dev/null || echo "unknown")
+
+    ids+=("$id")
+    types+=("$type")
+    dates+=("$date_str")
+    sizes+=("$(echo "$line" | grep -oP '[0-9]+[KMGT]B' | head -1 || echo 'unknown')")
+    storages+=("$stg")
+  done < <(grep -i 'vzdump' /var/log/syslog 2>/dev/null | tail -500 || true)
+
+  # Also scan backup storage directories for files
+  for storage_name in $(ls -d /var/lib/vz/dump/* 2>/dev/null | xargs -I{} basename {} || true); do
+    [[ -z "$storage_name" ]] && continue
+    [[ -n "$storage" && "$storage_name" != "$storage" ]] && continue
+
+    while IFS= read -r file; do
+      [[ -z "$file" ]] && continue
+      fname=$(basename "$file")
+
+      id=""
+      type="vm"
+      if [[ "$fname" =~ ^vzdump-qemu-([0-9]+)- ]]; then
+        id="${BASH_REMATCH[1]}"
+        type="vm"
+      elif [[ "$fname" =~ ^vzdump-lxc-([0-9]+)- ]]; then
+        id="${BASH_REMATCH[1]}"
+        type="ct"
+      elif [[ "$fname" =~ ^vzdump-([0-9]+)- ]]; then
+        id="${BASH_REMATCH[1]}"
+        type="vm"
+      fi
+
+      [[ -z "$id" ]] && continue
+
+      if [[ -n "$vmid" && "$id" != "$vmid" ]]; then continue; fi
+      if [[ -n "$ctid" && "$id" != "$ctid" ]]; then continue; fi
+
+      file_date=$(stat -f '%Sm' -t '%Y-%m-%d' "$file" 2>/dev/null || echo "unknown")
+      file_size=$(stat -f '%z' "$file" 2>/dev/null || echo 0)
+      file_size_human=""
+      if [[ $file_size -gt 1073741824 ]]; then
+        file_size_human="$((file_size / 1073741824))G"
+      elif [[ $file_size -gt 1048576 ]]; then
+        file_size_human="$((file_size / 1048576))M"
+      elif [[ $file_size -gt 1024 ]]; then
+        file_size_human="$((file_size / 1024))K"
+      fi
+
+      ids+=("$id")
+      types+=("$type")
+      dates+=("$file_date")
+      sizes+=("${file_size_human:-unknown}")
+      storages+=("$storage_name")
+    done < <(find "/var/lib/vz/dump/${storage_name}" -maxdepth 1 -type f \( -name '*.tar*' -o -name '*.zst' -o -name '*.gz' -o -name '*.lzo' \) 2>/dev/null || true)
+  done
+
+  # Also check other storage locations
+  while IFS= read -r storage_path; do
+    [[ -z "$storage_path" ]] && continue
+    [[ -d "$storage_path/backups" ]] || continue
+    stg_name=$(echo "$storage_path" | sed 's|.*/pve/storage/||;s|/.*||')
+    [[ -n "$storage" && "$stg_name" != "$storage" ]] && continue
+
+    while IFS= read -r file; do
+      [[ -z "$file" ]] && continue
+      fname=$(basename "$file")
+
+      id=""
+      type="vm"
+      if [[ "$fname" =~ ^vzdump-qemu-([0-9]+)- ]]; then
+        id="${BASH_REMATCH[1]}"
+        type="vm"
+      elif [[ "$fname" =~ ^vzdump-lxc-([0-9]+)- ]]; then
+        id="${BASH_REMATCH[1]}"
+        type="ct"
+      elif [[ "$fname" =~ ^vzdump-([0-9]+)- ]]; then
+        id="${BASH_REMATCH[1]}"
+        type="vm"
+      fi
+
+      [[ -z "$id" ]] && continue
+
+      if [[ -n "$vmid" && "$id" != "$vmid" ]]; then continue; fi
+      if [[ -n "$ctid" && "$id" != "$ctid" ]]; then continue; fi
+
+      file_date=$(stat -f '%Sm' -t '%Y-%m-%d' "$file" 2>/dev/null || echo "unknown")
+      file_size=$(stat -f '%z' "$file" 2>/dev/null || echo 0)
+      file_size_human=""
+      if [[ $file_size -gt 1073741824 ]]; then
+        file_size_human="$((file_size / 1073741824))G"
+      elif [[ $file_size -gt 1048576 ]]; then
+        file_size_human="$((file_size / 1048576))M"
+      elif [[ $file_size -gt 1024 ]]; then
+        file_size_human="$((file_size / 1024))K"
+      fi
+
+      ids+=("$id")
+      types+=("$type")
+      dates+=("$file_date")
+      sizes+=("${file_size_human:-unknown}")
+      storages+=("$stg_name")
+    done < <(find "$storage_path/backups" -maxdepth 1 -type f \( -name '*.tar*' -o -name '*.zst' -o -name '*.gz' -o -name '*.lzo' \) 2>/dev/null || true)
+  done < <(find /etc/pve -name 'storage.conf' -exec dirname {} \; 2>/dev/null || true)
+else
+  # Remote mode: use pvesh to list backup content from each storage
+  log_info "Remote mode: querying API for backup content"
+
+  while IFS= read -r node; do
+    [[ -z "$node" ]] && continue
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      [[ "$line" == "type:"* ]] && continue
+
+      stg=$(echo "$line" | awk -F: '{print $1}' | xargs)
+      [[ -n "$storage" && "$stg" != "$storage" ]] && continue
+
+      while IFS= read -r bfile; do
+        [[ -z "$bfile" ]] && continue
+        bname=$(basename "$bfile")
+
+        id=""
+        type="vm"
+        if [[ "$bname" =~ ^vzdump-qemu-([0-9]+)- ]]; then
+          id="${BASH_REMATCH[1]}"
+          type="vm"
+        elif [[ "$bname" =~ ^vzdump-lxc-([0-9]+)- ]]; then
+          id="${BASH_REMATCH[1]}"
+          type="ct"
+        elif [[ "$bname" =~ ^dump\. ]]; then
+          id=$(echo "$bname" | sed 's/dump\.//;s/\.lzo//;s/\.gz//;s/\.zst//;s/\.tar//')
+          type="vm"
+        fi
+
+        [[ -z "$id" ]] && continue
+
+        if [[ -n "$vmid" && "$id" != "$vmid" ]]; then continue; fi
+        if [[ -n "$ctid" && "$id" != "$ctid" ]]; then continue; fi
+
+        ids+=("$id")
+        types+=("$type")
+        dates+=("unknown")
+        sizes+=("unknown")
+        storages+=("$stg")
+      done < <(pvesh get "/nodes/$node/storage/$stg/content" --content backup 2>/dev/null || true)
+    done < <(pvesh get "/nodes/$node/storage" 2>/dev/null || true)
+  done < <(pvesh get /nodes 2>/dev/null | awk -F: '{print $1}' || true)
+fi
+
+# Deduplicate by id+date+storage
+declare -A seen=()
+declare -a u_ids=()
+declare -a u_types=()
+declare -a u_dates=()
+declare -a u_sizes=()
+declare -a u_storages=()
+
+for i in "${!ids[@]}"; do
+  key="${ids[$i]}-${dates[$i]}-${storages[$i]}"
+  if [[ -z "${seen[$key]:-}" ]]; then
+    seen[$key]=1
+    u_ids+=("${ids[$i]}")
+    u_types+=("${types[$i]}")
+    u_dates+=("${dates[$i]}")
+    u_sizes+=("${sizes[$i]}")
+    u_storages+=("${storages[$i]}")
+  fi
+done
+
+if [[ $output_json -eq 1 ]]; then
+  echo "["
+  first=1
+  for i in "${!u_ids[@]}"; do
+    [[ $first -eq 1 ]] && first=0 || echo ","
+    printf '  {"id": %s, "type": "%s", "date": "%s", "size": "%s", "storage": "%s"}' \
+      "${u_ids[$i]}" "${u_types[$i]}" "${u_dates[$i]}" "${u_sizes[$i]}" "${u_storages[$i]}"
+  done
+  echo ""
+  echo "]"
+else
+  printf "%-8s %-6s %-12s %-12s %-15s\n" "ID" "TYPE" "DATE" "SIZE" "STORAGE"
+  printf "%-8s %-6s %-12s %-12s %-15s\n" "--------" "------" "------------" "------------" "---------------"
+  for i in "${!u_ids[@]}"; do
+    printf "%-8s %-6s %-12s %-12s %-15s\n" \
+      "${u_ids[$i]}" "${u_types[$i]}" "${u_dates[$i]}" "${u_sizes[$i]}" "${u_storages[$i]}"
+  done
+fi
+
+echo ""
+log_info "Total backups found: ${#u_ids[@]}"

--- a/scripts/backup/gfs_retention.sh
+++ b/scripts/backup/gfs_retention.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Manage GFS (Grandfather-Father-Son) backup retention
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Manage GFS backup retention policy.
+
+Options:
+  --storage <store>    Backup storage name (default: $DEFAULT_STORAGE)
+  --keep-daily <n>     Keep N daily backups (default: 7)
+  --keep-weekly <n>    Keep N weekly backups (default: 4)
+  --keep-monthly <n>   Keep N monthly backups (default: 6)
+  --keep-yearly <n>    Keep N yearly backups (default: 1)
+  --dry-run            Show what would be deleted without deleting
+  --force              Skip confirmation prompt
+  -h, --help           Show this help
+
+Examples:
+  $(basename "$0") --dry-run              # Preview deletions
+  $(basename "$0") --keep-daily 14 --force  # 14 days retention
+EOF
+}
+
+storage="$DEFAULT_STORAGE"
+keep_daily=7
+keep_weekly=4
+keep_monthly=6
+keep_yearly=1
+dry_run=1
+force=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --storage)     storage="$2"; shift 2 ;;
+    --keep-daily)  keep_daily="$2"; shift 2 ;;
+    --keep-weekly) keep_weekly="$2"; shift 2 ;;
+    --keep-monthly) keep_monthly="$2"; shift 2 ;;
+    --keep-yearly) keep_yearly="$2"; shift 2 ;;
+    --dry-run)     dry_run=1; shift ;;
+    --force)       force=1; dry_run=0; shift ;;
+    -h|--help)     usage; exit 0 ;;
+    *)             die "Unknown option: $1" ;;
+  esac
+done
+
+# Validate numeric params
+[[ "$keep_daily" =~ ^[0-9]+$ ]] || die "keep-daily must be a positive integer"
+[[ "$keep_weekly" =~ ^[0-9]+$ ]] || die "keep-weekly must be a positive integer"
+[[ "$keep_monthly" =~ ^[0-9]+$ ]] || die "keep-monthly must be a positive integer"
+[[ "$keep_yearly" =~ ^[0-9]+$ ]] || die "keep-yearly must be a positive integer"
+
+log_info "GFS Retention Policy"
+log_info "  Daily:   $keep_daily"
+log_info "  Weekly:  $keep_weekly"
+log_info "  Monthly: $keep_monthly"
+log_info "  Yearly:  $keep_yearly"
+log_info "  Storage: $storage"
+echo ""
+
+# Find backup files
+backup_files=$(find /var/lib/vz/dump/ -name "*.vma*" -o -name "*.tar*" 2>/dev/null || true)
+if [[ -z "$backup_files" ]]; then
+  log_info "No backup files found in /var/lib/vz/dump/"
+  exit 0
+fi
+
+# Parse backups by date
+declare -a to_delete=()
+declare -a to_keep=()
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  file_date=$(stat -c %Y "$file" 2>/dev/null || echo "0")
+  current_date=$(date +%s)
+  age_days=$(( (current_date - file_date) / 86400 ))
+
+  # Categorize by age
+  if [[ $age_days -le $keep_daily ]]; then
+    to_keep+=("$file")
+  elif [[ $age_days -le $((keep_daily + keep_weekly * 7)) ]]; then
+    # Weekly retention - keep one per week
+    week_num=$(date -d "@$file_date" +%V 2>/dev/null || echo "0")
+    to_keep+=("$file")
+  elif [[ $age_days -le $((keep_daily + keep_weekly * 7 + keep_monthly * 30)) ]]; then
+    # Monthly retention - keep one per month
+    month=$(date -d "@$file_date" +%Y-%m 2>/dev/null || echo "00")
+    to_keep+=("$file")
+  elif [[ $age_days -le $((keep_daily + keep_weekly * 7 + keep_monthly * 30 + keep_yearly * 365)) ]]; then
+    # Yearly retention
+    year=$(date -d "@$file_date" +%Y 2>/dev/null || echo "0000")
+    to_keep+=("$file")
+  else
+    to_delete+=("$file")
+  fi
+done <<< "$backup_files"
+
+if [[ ${#to_delete[@]} -eq 0 ]]; then
+  log_info "No backups to delete"
+  exit 0
+fi
+
+echo ""
+log_warn "=== Backups to Delete ==="
+for f in "${to_delete[@]}"; do
+  log_info "  $f"
+done
+echo ""
+log_info "Total: ${#to_delete[@]} backups to delete"
+log_info "Keeping: ${#to_keep[@]} backups"
+echo ""
+
+if [[ $dry_run -eq 1 ]]; then
+  log_info "Dry run mode - no files deleted"
+  exit 0
+fi
+
+if [[ $force -eq 0 ]]; then
+  confirm "Delete ${#to_delete[@]} backup files?"
+fi
+
+for f in "${to_delete[@]}"; do
+  log_info "Deleting: $f"
+  rm -f "$f"
+done
+
+echo ""
+log_info "Retention cleanup complete"
+log_info "Deleted: ${#to_delete[@]} files"
+log_info "Kept: ${#to_keep[@]} files"

--- a/scripts/containers/create_lxc.sh
+++ b/scripts/containers/create_lxc.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Create an LXC container from a template
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --ctid <id> --template <ostemplate> --hostname <name> \
+       --ip <ip/cidr> --gateway <gw> [options]
+
+Create an LXC container from a template with network configuration.
+
+Required:
+  --ctid <id>        Container ID (must be >= 100)
+  --template <name>  Template name (e.g. local:vztmpl/debian-12-standard.tar.zst)
+  --hostname <name>  Container hostname
+  --ip <ip/cidr>     Static IP with CIDR (e.g. 10.0.1.50/24)
+  --gateway <gw>     Gateway IP
+
+Optional:
+  --storage <store>  Storage for rootfs (default: $DEFAULT_STORAGE)
+  --memory <mb>      Memory in MB (default: 512)
+  --swap <mb>        Swap in MB (default: 512)
+  --cores <n>        vCPU count (default: 1)
+  --unprivileged     Create unprivileged container (default: privileged)
+  --start            Start the container after creation
+  --sshkey <path>    SSH public key path
+  --dns <server>     DNS server (default: gateway IP)
+  -h, --help         Show this help
+
+Examples:
+  $(basename "$0") --ctid 200 --template local:vztmpl/debian-12-standard.tar.zst \
+    --hostname web01 --ip 10.0.1.50/24 --gateway 10.0.1.1 --start
+EOF
+}
+
+ctid=""
+template=""
+hostname=""
+ip_cidr=""
+gateway=""
+storage="$DEFAULT_STORAGE"
+memory=512
+swap=512
+cores=1
+unprivileged=0
+start=0
+ssh_key=""
+dns=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ctid)       ctid="$2"; shift 2 ;;
+    --template)   template="$2"; shift 2 ;;
+    --hostname)   hostname="$2"; shift 2 ;;
+    --ip)         ip_cidr="$2"; shift 2 ;;
+    --gateway)    gateway="$2"; shift 2 ;;
+    --storage)    storage="$2"; shift 2 ;;
+    --memory)     memory="$2"; shift 2 ;;
+    --swap)       swap="$2"; shift 2 ;;
+    --cores)      cores="$2"; shift 2 ;;
+    --unprivileged) unprivileged=1; shift ;;
+    --start)      start=1; shift ;;
+    --sshkey)     ssh_key="$2"; shift 2 ;;
+    --dns)        dns="$2"; shift 2 ;;
+    -h|--help)    usage; exit 0 ;;
+    *)            die "Unknown option: $1" ;;
+  esac
+done
+
+# Validate required args
+[[ -n "$ctid" ]] || die "--ctid is required"
+[[ -n "$template" ]] || die "--template is required"
+[[ -n "$hostname" ]] || die "--hostname is required"
+[[ -n "$ip_cidr" ]] || die "--ip is required"
+[[ -n "$gateway" ]] || die "--gateway is required"
+
+validate_vmid "$ctid"
+validate_ip "$ip_cidr"
+
+# Validate numeric params
+[[ "$memory" =~ ^[0-9]+$ ]] || die "Memory must be a positive integer"
+[[ "$swap" =~ ^[0-9]+$ ]] || die "Swap must be a positive integer"
+[[ "$cores" =~ ^[0-9]+$ ]] || die "Cores must be a positive integer"
+
+# Check CT doesn't exist
+if check_ct_exists "$ctid"; then
+  die "CTID $ctid already exists"
+fi
+
+# DNS defaults to gateway
+[[ -n "$dns" ]] || dns="$gateway"
+
+# Build pct create command
+log_info "Creating container $ctid ($hostname)"
+
+pct create "$ctid" "$template" \
+  --hostname "$hostname" \
+  --storage "$storage" \
+  --rootfs "${storage}:$(printf '%sG' "$((memory / 100 * 8))")" \
+  --memory "$memory" \
+  --swap "$swap" \
+  --cores "$cores" \
+  --net0 "name=eth0,bridge=${DEFAULT_BRIDGE},ip=${ip_cidr},gw=${gateway}" \
+  --nameserver "$dns" \
+  ${unprivileged:+--unprivileged 1}
+
+# SSH key
+if [[ -n "$ssh_key" ]]; then
+  ensure_ssh_key "$ssh_key"
+  pct setkey "$ctid" "$ssh_key" 2>/dev/null || log_warn "Could not set SSH key (template may not support it)"
+fi
+
+if [[ $start -eq 1 ]]; then
+  log_info "Starting container $ctid"
+  pct start "$ctid"
+fi
+
+echo ""
+log_info "=== Container Ready ==="
+log_info "Hostname:  $hostname"
+log_info "CTID:      $ctid"
+log_info "IP:        $ip_cidr"
+log_info "Gateway:   $gateway"
+log_info "DNS:       $dns"
+log_info "Memory:    ${memory}MB / ${swap}MB swap"
+log_info "Cores:     $cores"
+[[ $unprivileged -eq 1 ]] && log_info "Mode:      unprivileged"
+echo ""
+if [[ $start -eq 1 ]]; then
+  log_info "SSH: ssh root@$(echo "$ip_cidr" | cut -d/ -f1)"
+else
+  log_warn "Container not started. Run 'pct start $ctid' to start it."
+fi

--- a/scripts/containers/destroy_lxc.sh
+++ b/scripts/containers/destroy_lxc.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Destroy an LXC container
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --ctid <id> [options]
+
+Destroy an LXC container.
+
+Required:
+  --ctid <id>    Container ID to destroy
+
+Optional:
+  --force        Skip confirmation prompt
+  -h, --help     Show this help
+
+Examples:
+  $(basename "$0") --ctid 200
+  $(basename "$0") --ctid 200 --force
+EOF
+}
+
+ctid=""
+force=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ctid)  ctid="$2"; shift 2 ;;
+    --force) force=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)       die "Unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$ctid" ]] || die "--ctid is required"
+validate_vmid "$ctid"
+
+check_ct_exists "$ctid" || die "CTID $ctid does not exist"
+
+# Get container details
+hostname=$(pct config "$ctid" 2>/dev/null | grep "^hostname:" | head -1 | sed 's/^hostname://')
+hostname="${hostname:-unknown}"
+
+status=$(pct status "$ctid" 2>/dev/null | awk '/^status:/ {print $2}')
+status="${status:-unknown}"
+
+echo ""
+log_warn "=== Destroy Container ==="
+log_info "Hostname: $hostname"
+log_info "CTID:     $ctid"
+log_info "Status:   $status"
+echo ""
+
+if [[ $force -eq 0 ]]; then
+  confirm "Destroy container $ctid ($hostname)?"
+fi
+
+# Stop if running
+if [[ "$status" == "running" ]]; then
+  log_info "Stopping container $ctid"
+  pct stop "$ctid"
+fi
+
+# Remove snapshots
+snapshots=$(pct listsnapshots "$ctid" 2>/dev/null | tail -n +2 || true)
+if [[ -n "$snapshots" ]]; then
+  log_info "Removing snapshots..."
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    snap_name=$(echo "$line" | awk '{print $1}')
+    pct delsnapshot "$ctid" "$snap_name" 2>/dev/null || true
+  done <<< "$snapshots"
+fi
+
+# Destroy
+log_info "Destroying container $ctid"
+pct destroy "$ctid" 2>/dev/null || true
+
+echo ""
+log_info "Container $ctid ($hostname) destroyed"

--- a/scripts/containers/list_containers.sh
+++ b/scripts/containers/list_containers.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# List LXC containers on a Proxmox node
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+List LXC containers on the local Proxmox node.
+
+Options:
+  --running    Show only running containers
+  --stopped    Show only stopped containers
+  --json       Output in JSON format
+  -h, --help   Show this help
+
+Examples:
+  $(basename "$0")              # List all containers
+  $(basename "$0") --running    # List running only
+  $(basename "$0") --json       # JSON output
+EOF
+}
+
+filter_running=0
+filter_stopped=0
+output_json=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --running)  filter_running=1; shift ;;
+    --stopped)  filter_stopped=1; shift ;;
+    --json)     output_json=1; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *)          die "Unknown option: $1" ;;
+  esac
+done
+
+# Collect container data
+declare -a ctids=()
+declare -a hostnames=()
+declare -a statuses=()
+declare -a cpus=()
+declare -a memories=()
+declare -a disks=()
+
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  ctid=$(echo "$line" | awk '{print $1}')
+  [[ -z "$ctid" ]] && continue
+
+  hostname=$(pct config "$ctid" 2>/dev/null | grep "^hostname:" | head -1 | sed 's/^hostname://')
+  hostname="${hostname:-}"
+
+  status=$(pct status "$ctid" 2>/dev/null | awk '/^status:/ {print $2}')
+  status="${status:-stopped}"
+
+  cpu=$(pct status "$ctid" 2>/dev/null | awk '/^cpu:/{printf "%.1f", $2}')"%"
+  cpu="${cpu:-0%}"
+
+  mem_total=$(pct status "$ctid" 2>/dev/null | awk '/^maxmem:/{print $2}')
+  mem_used=$(pct status "$ctid" 2>/dev/null | awk '/^mem:/{print $2}')
+  if [[ -n "$mem_total" && "$mem_total" -gt 0 ]] 2>/dev/null; then
+    mem="$((${mem_used:-0} * 100 / ${mem_total}))%"
+  else
+    mem="0%"
+  fi
+
+  ctids+=("$ctid")
+  hostnames+=("$hostname")
+  statuses+=("$status")
+  cpus+=("$cpu")
+  memories+=("$mem")
+  disks+=("N/A")
+done < <(pct list 2>/dev/null | awk 'NR>1 {print $1}')
+
+if [[ $output_json -eq 1 ]]; then
+  echo "["
+  first=1
+  for i in "${!ctids[@]}"; do
+    [[ $first -eq 1 ]] && first=0 || echo ","
+    status_filter=1
+    [[ $filter_running -eq 1 && "${statuses[$i]}" != "running" ]] && status_filter=0
+    [[ $filter_stopped -eq 1 && "${statuses[$i]}" != "stopped" ]] && status_filter=0
+    [[ $status_filter -eq 1 ]] || continue
+    printf '  {"id": %s, "hostname": "%s", "status": "%s", "cpu": "%s", "memory": "%s"}' \
+      "${ctids[$i]}" "${hostnames[$i]}" "${statuses[$i]}" "${cpus[$i]}" "${memories[$i]}"
+  done
+  echo ""
+  echo "]"
+else
+  printf "%-8s %-20s %-10s %-10s %-10s\n" "CTID" "HOSTNAME" "STATUS" "CPU" "MEM"
+  printf "%-8s %-20s %-10s %-10s %-10s\n" "--------" "--------------------" "----------" "----------" "----------"
+  for i in "${!ctids[@]}"; do
+    status_filter=1
+    [[ $filter_running -eq 1 && "${statuses[$i]}" != "running" ]] && status_filter=0
+    [[ $filter_stopped -eq 1 && "${statuses[$i]}" != "stopped" ]] && status_filter=0
+    [[ $status_filter -eq 1 ]] || continue
+    printf "%-8s %-20s %-10s %-10s %-10s\n" \
+      "${ctids[$i]}" "${hostnames[$i]:0:20}" "${statuses[$i]}" "${cpus[$i]}" "${memories[$i]}"
+  done
+fi

--- a/scripts/network/network_report.sh
+++ b/scripts/network/network_report.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Generate a network report for the Proxmox host
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Generate a network configuration report.
+
+Options:
+  --json             Output in JSON format
+  -h, --help         Show this help
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") --json
+EOF
+}
+
+output_json=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) output_json=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)      die "Unknown option: $1" ;;
+  esac
+done
+
+log_info "=== Network Report ==="
+echo ""
+
+# Physical interfaces
+log_info "--- Physical Interfaces ---"
+if command -v ip &>/dev/null; then
+  ip -br addr show 2>/dev/null || log_warn "Could not retrieve interface info"
+elif command -v ifconfig &>/dev/null; then
+  ifconfig -a 2>/dev/null || log_warn "Could not retrieve interface info"
+fi
+echo ""
+
+# Proxmox network configuration
+log_info "--- Proxmox Network Configuration ---"
+if [[ -f /etc/network/interfaces ]]; then
+  cat /etc/network/interfaces 2>/dev/null || log_warn "Could not read /etc/network/interfaces"
+elif command -v pvesh &>/dev/null; then
+  pvesh get /nodes/$(hostname)/network 2>/dev/null || log_warn "Could not retrieve network config"
+fi
+echo ""
+
+# Bridge information
+log_info "--- Bridges ---"
+if command -v brctl &>/dev/null; then
+  brctl show 2>/dev/null || log_warn "Could not retrieve bridge info"
+elif command -v ip &>/dev/null; then
+  ip link show type bridge 2>/dev/null || log_warn "Could not retrieve bridge info"
+fi
+echo ""
+
+# DNS configuration
+log_info "--- DNS Configuration ---"
+if [[ -f /etc/resolv.conf ]]; then
+  grep -v '^#' /etc/resolv.conf 2>/dev/null | grep -v '^$' || log_warn "No DNS config found"
+fi
+echo ""
+
+# Routing table
+log_info "--- Routing Table ---"
+if command -v ip &>/dev/null; then
+  ip route show 2>/dev/null || log_warn "Could not retrieve routing table"
+fi
+echo ""
+
+# Connected VMs/containers
+log_info "--- Network Usage ---"
+log_info "Checking VMs..."
+qm list 2>/dev/null | awk 'NR>1 {print "  VM " $1 ": " $2}' || true
+echo ""
+log_info "Checking Containers..."
+pct list 2>/dev/null | awk 'NR>1 {print "  CT " $1 ": " $2}' || true
+echo ""
+
+log_info "=== End of Report ==="

--- a/scripts/network/vlan_setup.sh
+++ b/scripts/network/vlan_setup.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Set up a VLAN network configuration
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --vlan <id> --bridge <name> --parent <iface> [options]
+
+Set up a VLAN network configuration on Proxmox.
+
+Required:
+  --vlan <id>        VLAN ID (1-4094)
+  --bridge <name>    Bridge name (e.g. vmbr10)
+  --parent <iface>   Parent physical interface (e.g. eth0)
+
+Optional:
+  --description <d>  Bridge description
+  --dry-run          Show changes without applying
+  -h, --help         Show this help
+
+Examples:
+  $(basename "$0") --vlan 100 --bridge vmbr100 --parent eth0 --description "VLAN 100 - Dev"
+EOF
+}
+
+vlan=""
+bridge=""
+parent=""
+description=""
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vlan)        vlan="$2"; shift 2 ;;
+    --bridge)      bridge="$2"; shift 2 ;;
+    --parent)      parent="$2"; shift 2 ;;
+    --description) description="$2"; shift 2 ;;
+    --dry-run)     dry_run=1; shift ;;
+    -h|--help)     usage; exit 0 ;;
+    *)             die "Unknown option: $1" ;;
+  esac
+done
+
+# Validate required args
+[[ -n "$vlan" ]] || die "--vlan is required"
+[[ -n "$bridge" ]] || die "--bridge is required"
+[[ -n "$parent" ]] || die "--parent is required"
+
+# Validate VLAN ID
+[[ "$vlan" =~ ^[0-9]+$ ]] || die "VLAN ID must be a positive integer"
+[[ "$vlan" -ge 1 && "$vlan" -le 4094 ]] || die "VLAN ID must be between 1 and 4094"
+
+# Validate bridge name format
+[[ "$bridge" =~ ^[a-z][a-z0-9]*$ ]] || die "Bridge name must start with a letter"
+
+# Validate parent interface
+[[ "$parent" =~ ^[a-z0-9.]+$ ]] || die "Invalid parent interface name"
+
+log_info "=== VLAN Network Setup ==="
+log_info "VLAN:       $vlan"
+log_info "Bridge:     $bridge"
+log_info "Parent:     $parent"
+[[ -n "$description" ]] && log_info "Description: $description"
+echo ""
+
+# Check parent interface exists
+if ! ip link show "$parent" &>/dev/null; then
+  die "Parent interface $parent not found"
+fi
+
+# Generate network config
+network_config="/etc/network/interfaces.d/${bridge}.cfg"
+
+config_line="auto ${bridge}.${vlan}
+iface ${bridge}.${vlan} inet manual
+    vlan-raw-device ${parent}
+    vlan-id ${vlan}"
+
+if [[ -n "$description" ]]; then
+  config_line="${config_line}
+    # ${description}"
+fi
+
+echo ""
+log_info "=== Network Configuration ==="
+echo "$config_line"
+echo ""
+
+if [[ $dry_run -eq 1 ]]; then
+  log_info "Dry run mode - no changes applied"
+  exit 0
+fi
+
+# Create config file
+if [[ -f "$network_config" ]]; then
+  log_warn "Config file exists: $network_config"
+  confirm "Overwrite?"
+fi
+
+log_info "Writing config to $network_config"
+echo "$config_line" > "$network_config"
+
+# Apply network config
+log_info "Applying network configuration..."
+if command -v pvesh &>/dev/null; then
+  pvesh set /nodes/$(hostname)/network 2>/dev/null || log_warn "Could not apply network config via pvesh"
+fi
+
+# Try to reload network
+if command -v ifreload &>/dev/null; then
+  ifreload -a 2>/dev/null || log_warn "Could not reload network interfaces"
+fi
+
+echo ""
+log_info "=== VLAN Setup Complete ==="
+log_info "Bridge: ${bridge}.${vlan}"
+log_info "Config: $network_config"
+echo ""
+log_info "You may need to restart networking: systemctl restart networking"

--- a/scripts/storage/cleanup_orphaned.sh
+++ b/scripts/storage/cleanup_orphaned.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Clean up orphaned disk images
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Find and clean up orphaned disk images that are not referenced by any VM.
+
+Options:
+  --storage <store>  Storage name to scan (default: all)
+  --dry-run          Show orphaned files without deleting
+  --force            Skip confirmation prompt
+  -h, --help         Show this help
+
+Examples:
+  $(basename "$0") --dry-run
+  $(basename "$0") --storage local-lvm --force
+EOF
+}
+
+storage=""
+dry_run=1
+force=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --storage) storage="$2"; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    --force)   force=1; dry_run=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)         die "Unknown option: $1" ;;
+  esac
+done
+
+log_info "=== Orphaned Disk Cleanup ==="
+echo ""
+
+# Get list of VMs
+declare -a vm_ids=()
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  vm_id=$(echo "$line" | awk '{print $1}')
+  [[ -n "$vm_id" ]] && vm_ids+=("$vm_id")
+done < <(qm list 2>/dev/null | awk 'NR>1 {print $1}')
+
+# Get list of containers
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  ct_id=$(echo "$line" | awk '{print $1}')
+  [[ -n "$ct_id" ]] && vm_ids+=("$ct_id")
+done < <(pct list 2>/dev/null | awk 'NR>1 {print $1}')
+
+log_info "Known VMs: ${#vm_ids[@]}"
+
+# Find disk images
+declare -a orphaned=()
+declare -a total_size=0
+
+# Search common storage locations
+search_dirs=()
+if [[ -n "$storage" ]]; then
+  search_dirs+=("/var/lib/vz/${storage}" "/var/lib/vz/dump")
+else
+  search_dirs+=("/var/lib/vz" "/var/lib/vz/dump")
+  # Add additional storage paths
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    store_name=$(echo "$line" | awk '{print $1}')
+    [[ "$store_name" == "name" ]] && continue
+    search_dirs+=("/var/lib/vz/${store_name}")
+  done < <(pvesm status --content images 2>/dev/null | awk 'NR>1 {print $1}' || true)
+fi
+
+for dir in "${search_dirs[@]}"; do
+  [[ -d "$dir" ]] || continue
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    # Check if file is referenced by any VM config
+    referenced=0
+    for vm_id in "${vm_ids[@]}"; do
+      if qm config "$vm_id" 2>/dev/null | grep -q "$file"; then
+        referenced=1
+        break
+      fi
+    done
+    if [[ $referenced -eq 0 ]]; then
+      file_size=$(stat -c %s "$file" 2>/dev/null || echo "0")
+      orphaned+=("$file")
+      total_size=$((total_size + file_size))
+    fi
+  done < <(find "$dir" -name "*.qcow2" -o -name "*.raw" -o -name "*.img" -o -name "*.vmdk" 2>/dev/null || true)
+done
+
+if [[ ${#orphaned[@]} -eq 0 ]]; then
+  log_info "No orphaned disk images found"
+  exit 0
+fi
+
+echo ""
+log_warn "=== Orphaned Files Found ==="
+for f in "${orphaned[@]}"; do
+  file_size=$(stat -c %s "$f" 2>/dev/null || echo "0")
+  human_size=$(numfmt --to=iec $file_size 2>/dev/null || echo "${file_size}B")
+  log_info "  $f (${human_size})"
+done
+echo ""
+
+human_total=$(numfmt --to=iec $total_size 2>/dev/null || echo "${total_size}B")
+log_info "Total orphaned: ${#orphaned[@]} files (${human_total})"
+echo ""
+
+if [[ $dry_run -eq 1 ]]; then
+  log_info "Dry run mode - no files deleted"
+  exit 0
+fi
+
+if [[ $force -eq 0 ]]; then
+  confirm "Delete ${#orphaned[@]} orphaned files (${human_total})?"
+fi
+
+deleted=0
+for f in "${orphaned[@]}"; do
+  log_info "Deleting: $f"
+  rm -f "$f" && deleted=$((deleted + 1))
+done
+
+echo ""
+log_info "Cleanup complete"
+log_info "Deleted: $deleted files"

--- a/scripts/vm/clone_cloud_init.sh
+++ b/scripts/vm/clone_cloud_init.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Clone a cloud-init template and configure with static IP, SSH key, and user
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --template <vmid> --name <name> --vmid <id> \
+       --ip <ip/cidr> --gateway <gw> [options]
+
+Clone a cloud-init template and configure a new VM with static IP and SSH key.
+
+Required:
+  --template <id>    Source template VMID
+  --name <name>      Destination VM name
+  --vmid <id>        Destination VMID (must be >= 100)
+  --ip <ip/cidr>     Static IP with CIDR (e.g. 10.0.1.50/24)
+  --gateway <gw>     Gateway IP (e.g. 10.0.1.1)
+
+Optional:
+  --cores <n>        vCPU count (default: 2)
+  --memory <mb>      Memory in MB (default: 2048)
+  --disk <size>      Disk size (default: 8G)
+  --storage <store>  Target storage (default: $DEFAULT_STORAGE)
+  --bridge <br>      Network bridge (default: $DEFAULT_BRIDGE)
+  --sshkey <path>    SSH public key path
+  --user <username>  Cloud-init username (default: ubuntu)
+  --dns <server>     DNS server (default: gateway IP)
+  --start            Start the VM after cloning
+  -h, --help         Show this help
+
+Examples:
+  $(basename "$0") --template 9000 --name dev-box --vmid 110 \
+    --ip 10.0.1.50/24 --gateway 10.0.1.1 --sshkey ~/.ssh/id_ed25519.pub --start
+EOF
+}
+
+template=""
+name=""
+vmid=""
+ip_cidr=""
+gateway=""
+cores=2
+memory=2048
+disk_size="8G"
+storage="$DEFAULT_STORAGE"
+bridge="$DEFAULT_BRIDGE"
+ssh_key=""
+ci_user="ubuntu"
+dns=""
+start=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --template) template="$2"; shift 2 ;;
+    --name)     name="$2"; shift 2 ;;
+    --vmid)     vmid="$2"; shift 2 ;;
+    --ip)       ip_cidr="$2"; shift 2 ;;
+    --gateway)  gateway="$2"; shift 2 ;;
+    --cores)    cores="$2"; shift 2 ;;
+    --memory)   memory="$2"; shift 2 ;;
+    --disk)     disk_size="$2"; shift 2 ;;
+    --storage)  storage="$2"; shift 2 ;;
+    --bridge)   bridge="$2"; shift 2 ;;
+    --sshkey)   ssh_key="$2"; shift 2 ;;
+    --user)     ci_user="$2"; shift 2 ;;
+    --dns)      dns="$2"; shift 2 ;;
+    --start)    start=1; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *)          die "Unknown option: $1" ;;
+  esac
+done
+
+# Validate required args
+[[ -n "$template" ]] || die "--template is required"
+[[ -n "$name" ]] || die "--name is required"
+[[ -n "$vmid" ]] || die "--vmid is required"
+[[ -n "$ip_cidr" ]] || die "--ip is required"
+[[ -n "$gateway" ]] || die "--gateway is required"
+
+validate_vmid "$vmid"
+validate_ip "$ip_cidr"
+
+# Validate template exists
+check_vm_exists "$template" || die "Template VMID $template does not exist"
+
+# Check destination doesn't exist
+if check_vm_exists "$vmid"; then
+  die "VMID $vmid already exists"
+fi
+
+# Validate numeric params
+[[ "$cores" =~ ^[0-9]+$ ]] || die "Cores must be a positive integer"
+[[ "$memory" =~ ^[0-9]+$ ]] || die "Memory must be a positive integer"
+
+# DNS defaults to gateway if not specified
+[[ -n "$dns" ]] || dns="$gateway"
+
+# SSH key validation
+if [[ -n "$ssh_key" ]]; then
+  ensure_ssh_key "$ssh_key"
+fi
+
+log_info "Cloning template $template -> $vmid ($name)"
+
+# Full clone
+qm clone "$template" "$vmid" --name "$name" --full 1
+log_info "Clone complete"
+
+# Set resources
+qm set "$vmid" --cores "$cores" --memory "$memory"
+log_info "Resources: ${cores} cores, ${memory}MB RAM"
+
+# Resize disk if specified
+qm set "$vmid" --scsi0 "${storage}:vm-${vmid}-disk-0,size=${disk_size}"
+log_info "Disk: ${disk_size}"
+
+# Network with cloud-init
+qm set "$vmid" --net0 "virtio,bridge=${bridge},ip=${ip_cidr},gw=${gateway}"
+qm set "$vmid" --ipconfig0 "ip=${ip_cidr},gw=${gateway}"
+qm set "$vmid" --nameserver "$dns"
+
+# Cloud-init user
+qm set "$vmid" --ciuser "$ci_user"
+
+# SSH key
+if [[ -n "$ssh_key" ]]; then
+  qm set "$vmid" --sshkey "$ssh_key"
+  log_info "SSH key deployed"
+fi
+
+# Set boot order
+qm set "$vmid" --boot c --bootdisk scsi0
+
+if [[ $start -eq 1 ]]; then
+  log_info "Starting VM $vmid"
+  qm start "$vmid"
+fi
+
+echo ""
+log_info "=== VM Ready ==="
+log_info "Name:    $name"
+log_info "VMID:    $vmid"
+log_info "IP:      $ip_cidr"
+log_info "Gateway: $gateway"
+log_info "DNS:     $dns"
+[[ -n "$ssh_key" ]] && log_info "SSH key: $ssh_key"
+echo ""
+if [[ $start -eq 1 ]]; then
+  log_info "SSH: ssh ${ci_user}@$(echo "$ip_cidr" | cut -d/ -f1)"
+else
+  log_warn "VM not started. Run 'qm start $vmid' to start it."
+fi

--- a/scripts/vm/create_template.sh
+++ b/scripts/vm/create_template.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Create a cloud-init enabled VM template
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --image <url|path> --name <template-name> --vmid <id> [options]
+
+Create a cloud-init enabled VM template from a disk image.
+
+Required:
+  --image <url|path>   Cloud image URL or local file path
+  --name <name>        Template name
+  --vmid <id>          VMID for the template (must be >= 100)
+
+Optional:
+  --storage <store>    Target storage (default: $DEFAULT_STORAGE)
+  --disk <size>        Disk size (default: 10G)
+  --cores <n>          vCPU count (default: 2)
+  --memory <mb>        Memory in MB (default: 2048)
+  --user <username>    Cloud-init username (default: ubuntu)
+  --sshkey <path>      SSH public key path
+  -h, --help           Show this help
+
+Examples:
+  $(basename "$0") --image https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img \
+    --name ubuntu-2404-template --vmid 9000
+EOF
+}
+
+image=""
+name=""
+vmid=""
+storage="$DEFAULT_STORAGE"
+disk_size="10G"
+cores=2
+memory=2048
+ci_user="ubuntu"
+ssh_key=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image)  image="$2"; shift 2 ;;
+    --name)   name="$2"; shift 2 ;;
+    --vmid)   vmid="$2"; shift 2 ;;
+    --storage) storage="$2"; shift 2 ;;
+    --disk)   disk_size="$2"; shift 2 ;;
+    --cores)  cores="$2"; shift 2 ;;
+    --memory) memory="$2"; shift 2 ;;
+    --user)   ci_user="$2"; shift 2 ;;
+    --sshkey) ssh_key="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *)        die "Unknown option: $1" ;;
+  esac
+done
+
+# Validate required args
+[[ -n "$image" ]] || die "--image is required"
+[[ -n "$name" ]] || die "--name is required"
+[[ -n "$vmid" ]] || die "--vmid is required"
+
+validate_vmid "$vmid"
+
+# Validate numeric params
+[[ "$cores" =~ ^[0-9]+$ ]] || die "Cores must be a positive integer"
+[[ "$memory" =~ ^[0-9]+$ ]] || die "Memory must be a positive integer"
+
+# Check VMID doesn't already exist
+if check_vm_exists "$vmid"; then
+  die "VMID $vmid already exists"
+fi
+
+# Download image if URL
+image_file="$(basename "$image")"
+if [[ "$image" =~ ^https?:// ]]; then
+  log_info "Downloading image from $image"
+  if [[ ! -f "$image_file" ]]; then
+    wget --https-only -O "$image_file" "$image" || die "Failed to download image"
+  fi
+elif [[ ! -f "$image" ]]; then
+  die "Image file not found: $image"
+fi
+
+log_info "Creating VM $vmid ($name)"
+qm create "$vmid" --memory "$memory" --cores "$cores" --name "$name" \
+  --net0 "virtio,bridge=$DEFAULT_BRIDGE"
+
+log_info "Importing disk to $storage"
+qm importdisk "$vmid" "$image_file" "$storage"
+
+log_info "Configuring VM"
+qm set "$vmid" --scsihw virtio-scsi-pci --scsi0 "${storage}:vm-${vmid}-disk-0"
+qm set "$vmid" --ide2 "${storage}:cloudinit"
+qm set "$vmid" --boot c --bootdisk scsi0
+qm resize "$vmid" scsi0 "$disk_size"
+qm set "$vmid" --ciuser "$ci_user"
+qm set "$vmid" --serial0 socket --vga serial0
+
+if [[ -n "$ssh_key" ]]; then
+  ensure_ssh_key "$ssh_key"
+  qm set "$vmid" --sshkey "$ssh_key"
+  log_info "SSH key attached"
+fi
+
+log_info "Converting to template"
+qm template "$vmid"
+
+echo ""
+log_info "=== Template Ready ==="
+log_info "Name:  $name"
+log_info "VMID:  $vmid"
+log_info "User:  $ci_user"
+[[ -n "$ssh_key" ]] && log_info "SSH:   $ssh_key"
+echo ""
+log_info "Clone with: $(basename "$0") --template $vmid ..."

--- a/scripts/vm/list_vms.sh
+++ b/scripts/vm/list_vms.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# List VMs and containers on a Proxmox node
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+List VMs and containers on the local Proxmox node.
+
+Options:
+  --running      Show only running VMs/containers
+  --stopped      Show only stopped VMs/containers
+  --templates    Show only templates
+  --json         Output in JSON format
+  -h, --help     Show this help
+
+Examples:
+  $(basename "$0")                 # List everything
+  $(basename "$0") --running       # List running only
+  $(basename "$0") --json          # JSON output
+EOF
+}
+
+filter_running=0
+filter_stopped=0
+filter_templates=0
+output_json=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --running)   filter_running=1; shift ;;
+    --stopped)   filter_stopped=1; shift ;;
+    --templates) filter_templates=1; shift ;;
+    --json)      output_json=1; shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *)           die "Unknown option: $1" ;;
+  esac
+done
+
+# Collect VM data
+declare -a vmids=()
+declare -a names=()
+declare -a statuses=()
+declare -a cpus=()
+declare -a memories=()
+declare -a disks=()
+declare -a types=()
+
+# VMs
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  vmid=$(echo "$line" | awk '{print $1}')
+  [[ -z "$vmid" ]] && continue
+
+  name=$(qm config "$vmid" 2>/dev/null | grep "^name:" | head -1 | sed 's/^name://')
+  name="${name:-}"
+
+  status=$(qm status "$vmid" 2>/dev/null | awk '/^status:/ {print $2}')
+  status="${status:-stopped}"
+
+  cpu=$(qm status "$vmid" 2>/dev/null | awk '/^cpu:/{printf "%.1f", $2}')"%"
+  cpu="${cpu:-0%}"
+
+  mem_total=$(qm status "$vmid" 2>/dev/null | awk '/^maxmem:/{print $2}')
+  mem_used=$(qm status "$vmid" 2>/dev/null | awk '/^mem:/{print $2}')
+  if [[ -n "$mem_total" && "$mem_total" -gt 0 ]] 2>/dev/null; then
+    mem="$((${mem_used:-0} * 100 / ${mem_total}))%"
+  else
+    mem="0%"
+  fi
+
+  # Get disk usage from config
+  disk_line=$(qm config "$vmid" 2>/dev/null | grep -E "^(scsi|virtio|sata)[0-9]" | head -5 | tr '\n' ';')
+  disk="N/A"
+
+  vmids+=("$vmid")
+  names+=("$name")
+  statuses+=("$status")
+  cpus+=("$cpu")
+  memories+=("$mem")
+  disks+=("$disk")
+  types+=("vm")
+done < <(qm list 2>/dev/null | awk 'NR>1 {print $1}')
+
+# Containers
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  ctid=$(echo "$line" | awk '{print $1}')
+  [[ -z "$ctid" ]] && continue
+
+  hostname=$(pct config "$ctid" 2>/dev/null | grep "^hostname:" | head -1 | sed 's/^hostname://')
+  hostname="${hostname:-}"
+
+  status=$(pct status "$ctid" 2>/dev/null | awk '/^status:/ {print $2}')
+  status="${status:-stopped}"
+
+  cpu=$(pct status "$ctid" 2>/dev/null | awk '/^cpu:/{printf "%.1f", $2}')"%"
+  cpu="${cpu:-0%}"
+
+  mem_total=$(pct status "$ctid" 2>/dev/null | awk '/^maxmem:/{print $2}')
+  mem_used=$(pct status "$ctid" 2>/dev/null | awk '/^mem:/{print $2}')
+  if [[ -n "$mem_total" && "$mem_total" -gt 0 ]] 2>/dev/null; then
+    mem="$((${mem_used:-0} * 100 / ${mem_total}))%"
+  else
+    mem="0%"
+  fi
+
+  vmids+=("$ctid")
+  names+=("$hostname")
+  statuses+=("$status")
+  cpus+=("$cpu")
+  memories+=("$mem")
+  disks+=("N/A")
+  types+=("lxc")
+done < <(pct list 2>/dev/null | awk 'NR>1 {print $1}')
+
+# Apply filters
+if [[ $output_json -eq 1 ]]; then
+  echo "["
+  local first=1
+  for i in "${!vmids[@]}"; do
+    [[ $first -eq 1 ]] && first=0 || echo ","
+    local status_filter=1
+    if [[ $filter_running -eq 1 && "${statuses[$i]}" != "running" ]]; then
+      status_filter=0
+    fi
+    if [[ $filter_stopped -eq 1 && "${statuses[$i]}" != "stopped" ]]; then
+      status_filter=0
+    fi
+    if [[ $filter_templates -eq 1 && "${names[$i]}" == "" ]]; then
+      status_filter=0
+    fi
+    [[ $status_filter -eq 1 ]] || continue
+    printf '  {"id": %s, "name": "%s", "type": "%s", "status": "%s", "cpu": "%s", "memory": "%s"}' \
+      "${vmids[$i]}" "${names[$i]}" "${types[$i]}" "${statuses[$i]}" "${cpus[$i]}" "${memories[$i]}"
+  done
+  echo ""
+  echo "]"
+else
+  printf "%-8s %-20s %-8s %-10s %-10s %-10s\n" "ID" "NAME" "TYPE" "STATUS" "CPU" "MEM"
+  printf "%-8s %-20s %-8s %-10s %-10s %-10s\n" "--------" "--------------------" "--------" "----------" "----------" "----------"
+  for i in "${!vmids[@]}"; do
+    local status_filter=1
+    if [[ $filter_running -eq 1 && "${statuses[$i]}" != "running" ]]; then
+      status_filter=0
+    fi
+    if [[ $filter_stopped -eq 1 && "${statuses[$i]}" != "stopped" ]]; then
+      status_filter=0
+    fi
+    if [[ $filter_templates -eq 1 && "${names[$i]}" == "" ]]; then
+      status_filter=0
+    fi
+    [[ $status_filter -eq 1 ]] || continue
+    printf "%-8s %-20s %-8s %-10s %-10s %-10s\n" \
+      "${vmids[$i]}" "${names[$i]:0:20}" "${types[$i]}" "${statuses[$i]}" "${cpus[$i]}" "${memories[$i]}"
+  done
+fi

--- a/scripts/vm/snapshot_vm.sh
+++ b/scripts/vm/snapshot_vm.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Create a snapshot of a VM
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --vmid <id> [options]
+
+Create a snapshot of a VM.
+
+Required:
+  --vmid <id>        VMID to snapshot
+
+Optional:
+  --name <name>      Snapshot name (default: YYYY-MM-DD-HHMMSS)
+  --description <d>  Snapshot description
+  -h, --help         Show this help
+
+Examples:
+  $(basename "$0") --vmid 100
+  $(basename "$0") --vmid 100 --name before-upgrade --description "Pre-upgrade state"
+EOF
+}
+
+vmid=""
+snap_name=""
+description=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vmid)        vmid="$2"; shift 2 ;;
+    --name)        snap_name="$2"; shift 2 ;;
+    --description) description="$2"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *)             die "Unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$vmid" ]] || die "--vmid is required"
+validate_vmid "$vmid"
+
+check_vm_exists "$vmid" || die "VMID $vmid does not exist"
+
+# Default snapshot name
+if [[ -z "$snap_name" ]]; then
+  snap_name="$(date +%Y-%m-%d-%H%M%S)"
+fi
+
+# Check VM status
+vm_status=$(qm status "$vmid" 2>/dev/null | awk '/^status:/ {print $2}')
+if [[ "$vm_status" == "stopped" ]]; then
+  log_warn "VM is stopped. Snapshot may not capture current state."
+  confirm "Continue anyway?"
+fi
+
+log_info "Creating snapshot '${snap_name}' for VM $vmid"
+qm snapshot "$vmid" "$snap_name" 2>&1 || die "Failed to create snapshot"
+
+if [[ -n "$description" ]]; then
+  qm set "$vmid" --description "$description" 2>&1 || log_warn "Could not set snapshot description"
+fi
+
+echo ""
+log_info "Snapshot created: $snap_name"
+log_info "Rollback: qm rollback $vmid $snap_name"


### PR DESCRIPTION
## Summary

Closes out the handoff from the Proxmox Utility Toolkit project. This PR includes all scripts, documentation, and fixes from the validation phase against Proxmox VE 8.x official docs.

## Scripts (13 total)

### VM Management (`scripts/vm/`)
- `list_vms.sh` — List all VMs with status
- `clone_cloud_init.sh` — Clone a cloud-init template with static IP, SSH key
- `create_template.sh` — Create a cloud-init enabled VM template from disk image
- `snapshot_vm.sh` — Create VM snapshots with rollback support

### LXC Containers (`scripts/containers/`)
- `create_lxc.sh` — Create LXC container from template with network config
- `destroy_lxc.sh` — Destroy container (stops, removes snapshots, removes)
- `list_containers.sh` — List all containers with status

### Backup (`scripts/backup/`)
- `backup_status.sh` — Check backup status from syslog + backup directories
- `gfs_retention.sh` — Enforce GFS backup retention policy

### Network (`scripts/network/`)
- `network_report.sh` — Generate network configuration report
- `vlan_setup.sh` — Configure VLANs on Proxmox bridges

### Storage (`scripts/storage/`)
- `cleanup_orphaned.sh` — Remove orphaned disk images

### API (`scripts/api/`)
- `api_wrapper.sh` — Generic Proxmox API wrapper with ticket/token auth

## Documentation (6 new files)
- `docs/getting_started.md` — Setup and first-run guide
- `docs/backup_strategy.md` — Backup strategy and GFS retention
- `docs/network_guide.md` — Network configuration guide
- `docs/storage_guide.md` — Storage configuration guide
- `docs/troubleshooting.md` — Common issues and fixes
- `docs/api_reference.md` — API call reference

## Other
- `LICENSE` — MIT License (2026 Derek Armstrong)
- `CONTRIBUTING.md` — Contribution guidelines
- Updated `README.md` and `lib/common.sh`

## Validation Fixes (from Proxmox VE 8.x docs review)
- **snapshot_vm.sh**: `qm snapshot` doesn't support `--description`; fixed to use `qm set --description` after snapshot
- **backup_status.sh**: `pvesm status --content backup` returns storage metadata, not backup files; rewrote to parse syslog `vzdump` entries + scan backup directories + use `pvesh` for remote mode